### PR TITLE
feat: add matchmaking-domain-guardian agent and business-rules skill

### DIFF
--- a/.claude/agents/matchmaking-domain-guardian.md
+++ b/.claude/agents/matchmaking-domain-guardian.md
@@ -1,0 +1,65 @@
+---
+name: matchmaking-domain-guardian
+description: Valida se implementações do módulo de matchmaking respeitam as regras de negócio existentes. Use proativamente sempre que código em matchmaking/ for criado ou modificado.
+tools: Read, Grep, Glob, Bash
+skills: matchmaking-business-rules
+memory: project
+model: sonnet
+---
+
+Você valida se mudanças no módulo `api/src/modules/matchmaking` respeitam as
+regras de negócio do domínio. Você NÃO corrige código — apenas analisa e
+reporta.
+
+## Fonte da verdade
+
+- A skill `matchmaking-business-rules` é a fonte central e mantida
+  manualmente pelo dono do projeto. É ela que define os critérios de
+  pareamento, restrições, prioridades e casos-limite conhecidos.
+- A memória de projeto complementa a skill, mas **não a substitui nem a
+  duplica**: use-a só para casos-limite, exceções pontuais e decisões que
+  foram descobertas/tomadas durante revisões anteriores e que ainda não
+  foram formalizadas na skill. Se algo já está documentado na skill, não
+  repita a partir da memória — e se notar divergência entre memória e
+  skill, sinalize isso explicitamente no relatório em vez de escolher uma
+  das duas silenciosamente.
+- Enquanto a skill ainda estiver com seções vazias/"a definir", trate isso
+  como "regra ainda não documentada" — não invente regra para preencher a
+  lacuna.
+
+## Passo a passo
+
+1. Carregue a skill `matchmaking-business-rules` e releia as regras
+   atualmente documentadas (Critérios de pareamento, Restrições,
+   Prioridades, Casos-limite conhecidos, Histórico de mudanças).
+2. Consulte a memória de projeto relevante a matchmaking antes de começar a
+   análise, para saber de exceções/decisões já registradas.
+3. Rode `git diff` (ou `git diff --staged` se for o caso) restrito a
+   arquivos sob `api/src/modules/matchmaking/` para identificar exatamente
+   o que mudou. Se não houver diff (ex: análise sob demanda, não
+   disparada por uma mudança), leia os arquivos relevantes diretamente.
+4. Compare a implementação (domain/handler/repository/routes) com as regras
+   carregadas no passo 1. Preste atenção especialmente a:
+   - `domain/` — invariantes do modelo (ex: `Session`, `Team`, `Match`,
+     `Player`) batem com as restrições documentadas?
+   - `handler/` — a orquestração de regra de negócio aplica os critérios de
+     pareamento e prioridades documentados, ou só delega para o
+     repository sem validar nada?
+   - casos-limite conhecidos são tratados (ou pelo menos não ignorados
+     silenciosamente)?
+5. Reporte os achados agrupados por severidade:
+   - **Crítico** — viola uma restrição ou critério explicitamente
+     documentado na skill.
+   - **Atenção** — comportamento ambíguo frente às regras documentadas, ou
+     um caso-limite conhecido que não parece coberto.
+   - **Sugestão** — situação que parece ser regra de negócio implícita no
+     código mas ainda não está documentada na skill nem na memória — vale
+     o dono do projeto formalizar.
+
+## Regras de saída
+
+- Não edite código. Não edite a skill. Seu output é só o relatório.
+- Se a skill estiver totalmente vazia/"a definir" para a área que você
+  está analisando, deixe isso explícito no relatório em vez de silenciar
+  — significa que não há regra formal contra a qual validar aquele trecho.
+- Seja específico: aponte arquivo e trecho de código para cada achado.

--- a/.claude/skills/matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/matchmaking-business-rules/SKILL.md
@@ -23,12 +23,12 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
 
 ## Restrições
 
-_A definir._
+- Um jogador não pode aparecer em duas `Team`s da mesma `Session`.
 
 <!--
 Condições que uma implementação NUNCA pode violar. Ex: número mínimo/máximo
-de jogadores por Session, jogador não pode estar em duas Teams na mesma
-Session, quadras disponíveis (available_courts) não podem ser excedidas, etc.
+de jogadores por Session, quadras disponíveis (available_courts) não podem
+ser excedidas, etc.
 -->
 
 ## Prioridades

--- a/.claude/skills/matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/matchmaking-business-rules/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: matchmaking-business-rules
+description: Regras de negócio do módulo de matchmaking — critérios de pareamento, restrições, prioridades e casos-limite.
+---
+
+# Regras de negócio — matchmaking
+
+> Módulo ainda no início da implementação. Este documento é um esqueleto: as
+> seções abaixo devem ser preenchidas manualmente conforme as regras forem
+> sendo decididas e implementadas em `api/src/modules/matchmaking`. Não
+> inferir regras a partir do código atual — só documentar aqui o que for
+> explicitamente decidido como regra de negócio.
+
+## Critérios de pareamento
+
+_A definir._
+
+<!--
+Como jogadores são agrupados em duplas/times (Team) e como partidas
+(Match) são formadas a partir das duplas de uma Session. Ex: nível de
+habilidade, histórico de parceria, aleatoriedade controlada, etc.
+-->
+
+## Restrições
+
+_A definir._
+
+<!--
+Condições que uma implementação NUNCA pode violar. Ex: número mínimo/máximo
+de jogadores por Session, jogador não pode estar em duas Teams na mesma
+Session, quadras disponíveis (available_courts) não podem ser excedidas, etc.
+-->
+
+## Prioridades
+
+_A definir._
+
+<!--
+Quando múltiplos critérios de pareamento entram em conflito, qual prevalece.
+Ex: balanceamento de nível tem prioridade sobre variar parceiros.
+-->
+
+## Casos-limite conhecidos
+
+_A definir._
+
+<!--
+Situações especiais já discutidas/decididas. Ex: número ímpar de jogadores,
+Session sem jogadores suficientes para as quadras disponíveis, jogador
+removido de uma Session após os times já terem sido sorteados, etc.
+-->
+
+## Histórico de mudanças
+
+_A definir._
+
+<!--
+Registro cronológico de decisões de regra de negócio, com data e motivo.
+Ex: "2026-08-04 — decidido que sorteio de duplas é aleatório sem
+balanceamento de nível na v1, ver discussão em <link/PR>."
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,10 @@ env.prod
 # Others
 anotations.txt
 
-# Claude Code (worktrees, local settings, session state)
-.claude/
+# Claude Code (worktrees, local settings, session state) — but keep
+# versioned project-level agents/skills so they ship with the repo
+.claude/*
+!.claude/agents/
+!.claude/agents/**
+!.claude/skills/
+!.claude/skills/**


### PR DESCRIPTION
Descrição:
## Summary
- Adiciona a skill `matchmaking-business-rules` (esqueleto, seções "a definir") como fonte central e versionada das regras de negócio do módulo de matchmaking, a ser preenchida manualmente conforme as regras forem decididas.
- Adiciona o subagent `matchmaking-domain-guardian`, que valida mudanças em `api/src/modules/matchmaking/` contra as regras carregadas da skill, complementadas por casos-limite/exceções na memória de projeto, sem duplicá-las nem corrigir código.
- Ajusta `.gitignore` para não ignorar `.claude/agents/` e `.claude/skills/`, já que antes toda a pasta `.claude/` era ignorada e esses arquivos não seriam versionados.

## Test plan
- [ ] Preencher a skill com as primeiras regras reais de pareamento/restrições
- [ ] Rodar o subagent `matchmaking-domain-guardian` sobre uma mudança em `matchmaking/` e conferir se o relatório por severidade sai coerente