### PR TITLE
feat(matchmaking): validate team formation rules via TeamValidator

### DIFF
--- a/.claude/skills/matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/matchmaking-business-rules/SKILL.md
@@ -24,6 +24,11 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
 ## Restrições
 
 - Um jogador não pode aparecer em duas `Team`s da mesma `Session`.
+- Um jogador não pode se repetir dentro da mesma `Team`.
+
+Ambas validadas por `TeamValidator::validate_new_team`
+(`api/src/modules/matchmaking/domain/team.rs`), chamado por
+`TeamHandlerImpl::create_team`.
 
 <!--
 Condições que uma implementação NUNCA pode violar. Ex: número mínimo/máximo
@@ -52,7 +57,9 @@ removido de uma Session após os times já terem sido sorteados, etc.
 
 ## Histórico de mudanças
 
-_A definir._
+- 2026-08-04 — implementada validação em `create_team`: rejeita jogador
+  duplicado dentro da mesma `Team` (`HttpError::bad_request`) e jogador já
+  presente em outra `Team` da mesma `Session` (`HttpError::conflict`).
 
 <!--
 Registro cronológico de decisões de regra de negócio, com data e motivo.

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -1,4 +1,7 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
+use http_error::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
@@ -31,5 +34,172 @@ getters! {
         session_id: Uuid,
         player_ids: Vec<Uuid>,
         created_at: DateTime<Utc>,
+    }
+}
+
+/// Centralizes the validation rules for forming a `Team` within a `Session`.
+/// Bound to a `session_id` at construction so it always scopes the
+/// "player already in another team" check to that session, regardless of
+/// what `existing_teams` the caller passes in.
+pub struct TeamValidator {
+    session_id: Uuid,
+}
+
+impl TeamValidator {
+    pub fn new(session_id: Uuid) -> Self {
+        Self { session_id }
+    }
+
+    /// A player cannot repeat within the same team, nor be in two teams of
+    /// the same session at the same time.
+    pub fn validate_new_team(
+        &self,
+        existing_teams: &[Team],
+        player_ids: &[Uuid],
+    ) -> HttpResult<()> {
+        Self::reject_duplicate_players_in_team(player_ids)?;
+        self.reject_players_already_in_session(existing_teams, player_ids)?;
+
+        Ok(())
+    }
+
+    fn reject_duplicate_players_in_team(player_ids: &[Uuid]) -> HttpResult<()> {
+        let mut seen = HashSet::with_capacity(player_ids.len());
+
+        for player_id in player_ids {
+            if !seen.insert(player_id) {
+                return Err(Box::new(HttpError::bad_request(format!(
+                    "Player {player_id} is duplicated in the same team"
+                ))));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn reject_players_already_in_session(
+        &self,
+        existing_teams: &[Team],
+        player_ids: &[Uuid],
+    ) -> HttpResult<()> {
+        let players_in_session: HashSet<&Uuid> = existing_teams
+            .iter()
+            .filter(|team| team.session_id() == &self.session_id)
+            .flat_map(|team| team.player_ids())
+            .collect();
+
+        if let Some(player_id) = player_ids
+            .iter()
+            .find(|player_id| players_in_session.contains(player_id))
+        {
+            return Err(Box::new(HttpError::conflict(format!(
+                "Player {player_id} is already in another team for this session"
+            ))));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_error::HttpErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn test_validate_new_team_with_no_existing_teams() {
+        let validator = TeamValidator::new(Uuid::new_v4());
+        let player_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+
+        assert!(validator.validate_new_team(&[], &player_ids).is_ok());
+    }
+
+    #[test]
+    fn test_validate_new_team_with_single_player() {
+        let validator = TeamValidator::new(Uuid::new_v4());
+        let player_ids = vec![Uuid::new_v4()];
+
+        assert!(validator.validate_new_team(&[], &player_ids).is_ok());
+    }
+
+    #[test]
+    fn test_validate_new_team_rejects_duplicated_player_in_same_team() {
+        let validator = TeamValidator::new(Uuid::new_v4());
+        let player_id = Uuid::new_v4();
+        let player_ids = vec![player_id, player_id];
+
+        let err = validator.validate_new_team(&[], &player_ids).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_validate_new_team_rejects_player_already_in_another_team_of_same_session() {
+        let session_id = Uuid::new_v4();
+        let repeated_player = Uuid::new_v4();
+
+        let validator = TeamValidator::new(session_id);
+        let existing_team = Team::new(session_id, vec![repeated_player, Uuid::new_v4()]);
+        let player_ids = vec![repeated_player, Uuid::new_v4()];
+
+        let err = validator
+            .validate_new_team(std::slice::from_ref(&existing_team), &player_ids)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_validate_new_team_allows_when_no_players_overlap_with_existing_team() {
+        let session_id = Uuid::new_v4();
+        let validator = TeamValidator::new(session_id);
+        let existing_team = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+        let player_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+
+        let result = validator.validate_new_team(std::slice::from_ref(&existing_team), &player_ids);
+
+        assert!(result.is_ok());
+    }
+
+    /// The validator scopes the check to its own `session_id`, so a team
+    /// belonging to a different session must not block a shared player,
+    /// even if the caller passes it in `existing_teams` by mistake.
+    #[test]
+    fn test_validate_new_team_ignores_teams_from_other_sessions() {
+        let session_id = Uuid::new_v4();
+        let other_session_id = Uuid::new_v4();
+        let shared_player = Uuid::new_v4();
+
+        let validator = TeamValidator::new(session_id);
+        let team_from_other_session =
+            Team::new(other_session_id, vec![shared_player, Uuid::new_v4()]);
+        let player_ids = vec![shared_player, Uuid::new_v4()];
+
+        let result = validator
+            .validate_new_team(std::slice::from_ref(&team_from_other_session), &player_ids);
+
+        assert!(result.is_ok());
+    }
+
+    /// With a mixed list, the session filter must reject the overlap coming
+    /// from the same-session team and ignore the other-session one.
+    #[test]
+    fn test_validate_new_team_filters_by_session_in_a_mixed_team_list() {
+        let session_id = Uuid::new_v4();
+        let other_session_id = Uuid::new_v4();
+        let repeated_player = Uuid::new_v4();
+
+        let validator = TeamValidator::new(session_id);
+        let team_in_same_session = Team::new(session_id, vec![repeated_player, Uuid::new_v4()]);
+        let team_in_other_session =
+            Team::new(other_session_id, vec![repeated_player, Uuid::new_v4()]);
+        let player_ids = vec![repeated_player, Uuid::new_v4()];
+
+        let err = validator
+            .validate_new_team(&[team_in_same_session, team_in_other_session], &player_ids)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
     }
 }

--- a/api/src/modules/matchmaking/handler/team.rs
+++ b/api/src/modules/matchmaking/handler/team.rs
@@ -5,7 +5,8 @@ use http_error::HttpResult;
 use uuid::Uuid;
 
 use crate::modules::matchmaking::{
-    domain::team::Team, handler::team::use_cases::CreateTeamRequest,
+    domain::team::{Team, TeamValidator},
+    handler::team::use_cases::CreateTeamRequest,
     repository::team::DynTeamRepository,
 };
 
@@ -26,6 +27,14 @@ pub struct TeamHandlerImpl {
 #[async_trait]
 impl TeamHandler for TeamHandlerImpl {
     async fn create_team(&self, request: CreateTeamRequest) -> HttpResult<Team> {
+        let existing_teams = self
+            .team_repository
+            .list_by_session(&request.session_id)
+            .await?;
+
+        TeamValidator::new(request.session_id)
+            .validate_new_team(&existing_teams, &request.player_ids)?;
+
         let team = Team::new(request.session_id, request.player_ids);
 
         self.team_repository.insert(team).await


### PR DESCRIPTION
Add TeamValidator, bound to a session_id at construction, to enforce that a player cannot repeat within the same team nor be in two teams of the same session. Wired into TeamHandlerImpl::create_team before insertion, with unit tests covering the duplicate, cross-team and cross-session scenarios.