### PR TITLE
feat(matchmaking): add GameMode filter and random team draw

### DIFF
--- a/.claude/skills/matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/matchmaking-business-rules/SKILL.md
@@ -13,7 +13,19 @@ description: Regras de negócio do módulo de matchmaking — critérios de pare
 
 ## Critérios de pareamento
 
-_A definir._
+- Toda `Session` tem um `GameMode` (`Male`, `Female` ou `Mixed`), que filtra
+  quem pode formar dupla junto: `Male`/`Female` só pareiam jogadores do
+  mesmo gênero; `Mixed` forma cada `Team` com metade dos jogadores homens e
+  metade mulheres (com `players_per_team = 2`, na prática 1 homem + 1
+  mulher).
+- O primeiro sorteio de `Team`s de uma `Session` é aleatório, sem nenhum
+  critério de balanceamento (nível, histórico de parceria, etc.) — v1
+  deliberadamente simples, pois no início da sessão não há histórico para
+  balancear. Sorteios futuros podem somar outros critérios em cima do
+  `GameMode`.
+- Implementado por `TeamDrawer::draw` (`api/src/modules/matchmaking/domain/team.rs`),
+  chamado por `TeamHandlerImpl::draw_teams` via `POST
+  /matchmaking/teams/{session_id}/draw`.
 
 <!--
 Como jogadores são agrupados em duplas/times (Team) e como partidas
@@ -25,10 +37,20 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
 
 - Um jogador não pode aparecer em duas `Team`s da mesma `Session`.
 - Um jogador não pode se repetir dentro da mesma `Team`.
+- `GameMode::Mixed` exige `players_per_team` par (para dividir metade
+  homens / metade mulheres por `Team`). Validado tanto na criação/edição da
+  `Session` (`GameMode::validate_players_per_team`, chamado por
+  `Session::new`/`set_settings`/`set_game_mode`) quanto no sorteio
+  (`TeamDrawer::draw`), para que uma `Session` nunca fique salva numa
+  configuração que o sorteio não consegue honrar.
+- `draw_teams` só pode ser chamado uma vez por `Session` (é o sorteio de
+  *inicialização*): se a `Session` já tiver alguma `Team`, retorna
+  `HttpError::conflict`. Não existe hoje endpoint para resetar/re-sortear.
 
-Ambas validadas por `TeamValidator::validate_new_team`
-(`api/src/modules/matchmaking/domain/team.rs`), chamado por
-`TeamHandlerImpl::create_team`.
+Restrições de duplicidade de jogador validadas por
+`TeamValidator::validate_new_team` (`api/src/modules/matchmaking/domain/team.rs`),
+chamado tanto por `TeamHandlerImpl::create_team` quanto por
+`TeamHandlerImpl::draw_teams`.
 
 <!--
 Condições que uma implementação NUNCA pode violar. Ex: número mínimo/máximo
@@ -47,7 +69,16 @@ Ex: balanceamento de nível tem prioridade sobre variar parceiros.
 
 ## Casos-limite conhecidos
 
-_A definir._
+- Jogadores que sobram sem completar um time cheio (ou, no modo `Mixed`, do
+  gênero que já se esgotou) ficam de fora do sorteio silenciosamente —
+  `draw_teams` retorna só os times formados, sem indicar quem ficou de fora.
+  Ainda não decidido se isso deve mudar (ex: devolver lista de não
+  alocados).
+- `draw_teams` faz o check de "sessão já tem times" e os inserts em
+  chamadas separadas ao repositório — duas chamadas concorrentes para a
+  mesma `Session` podem, em teoria, passar pelo check antes de qualquer
+  insert acontecer (TOCTOU). Não tratado ainda; aceitável hoje por ser
+  repositório em memória de processo único, sem carga concorrente real.
 
 <!--
 Situações especiais já discutidas/decididas. Ex: número ímpar de jogadores,
@@ -60,6 +91,10 @@ removido de uma Session após os times já terem sido sorteados, etc.
 - 2026-08-04 — implementada validação em `create_team`: rejeita jogador
   duplicado dentro da mesma `Team` (`HttpError::bad_request`) e jogador já
   presente em outra `Team` da mesma `Session` (`HttpError::conflict`).
+- 2026-08-04 — adicionado `GameMode` (`Male`/`Female`/`Mixed`) como campo
+  obrigatório de `Session`, e rota `POST /matchmaking/teams/{session_id}/draw`
+  para o sorteio inicial (aleatório) de `Team`s a partir dos jogadores
+  confirmados na `Session`, respeitando o `GameMode`.
 
 <!--
 Registro cronológico de decisões de regra de negócio, com data e motivo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "database",
  "http-error",
  "jsonwebtoken",
+ "rand",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 async-trait = { version = "0.1.87" }
 reqwest = { version = "0.12.24", features = ["json"] }
+rand = { version = "0.8" }
 
 # Data Models
 chrono = { version = "0.4.42", features = ["serde"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,6 +14,7 @@ rust_decimal = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }
 serde_plain = { workspace = true }
+rand = { workspace = true }
 
 ## Auth
 bcrypt = { workspace = true }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -129,15 +129,21 @@ fn build_income_handler(pool: &Pool<Postgres>) -> IncomeHandlerImpl {
 }
 
 fn build_matchmaking_state() -> MatchmakingState {
+    let player_repository = Arc::new(InMemoryPlayerRepository::new());
+    let session_repository = Arc::new(InMemorySessionRepository::new());
+    let team_repository = Arc::new(InMemoryTeamRepository::new());
+
     MatchmakingState {
         player_handler: Arc::new(PlayerHandlerImpl {
-            player_repository: Arc::new(InMemoryPlayerRepository::new()),
+            player_repository: player_repository.clone(),
         }),
         session_handler: Arc::new(SessionHandlerImpl {
-            session_repository: Arc::new(InMemorySessionRepository::new()),
+            session_repository: session_repository.clone(),
         }),
         team_handler: Arc::new(TeamHandlerImpl {
-            team_repository: Arc::new(InMemoryTeamRepository::new()),
+            team_repository,
+            session_repository,
+            player_repository,
         }),
         match_handler: Arc::new(MatchHandlerImpl {
             match_repository: Arc::new(InMemoryMatchRepository::new()),

--- a/api/src/modules/matchmaking/domain/session.rs
+++ b/api/src/modules/matchmaking/domain/session.rs
@@ -1,7 +1,34 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use http_error::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
+
+/// Filter applied when drawing teams for a `Session`: pairs restricted to
+/// men, restricted to women, or mixed (1 man + 1 woman per team).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GameMode {
+    Male,
+    Female,
+    Mixed,
+}
+
+impl GameMode {
+    /// `Mixed` needs to split `players_per_team` evenly between men and
+    /// women, so it only makes sense for an even count. Checked here, at the
+    /// Session boundary, so a Session can never be saved in a configuration
+    /// that a later team draw would be unable to honor.
+    pub fn validate_players_per_team(&self, players_per_team: u8) -> HttpResult<()> {
+        if *self == GameMode::Mixed && !players_per_team.is_multiple_of(2) {
+            return Err(Box::new(HttpError::bad_request(
+                "Mixed game mode requires an even number of players per team",
+            )));
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,22 +65,31 @@ pub struct Session {
     date: NaiveDate,
     settings: SessionSettings,
     available_courts: u8,
+    game_mode: GameMode,
     player_ids: Vec<Uuid>,
     created_at: DateTime<Utc>,
     updated_at: Option<DateTime<Utc>>,
 }
 
 impl Session {
-    pub fn new(date: NaiveDate, settings: SessionSettings, available_courts: u8) -> Self {
-        Self {
+    pub fn new(
+        date: NaiveDate,
+        settings: SessionSettings,
+        available_courts: u8,
+        game_mode: GameMode,
+    ) -> HttpResult<Self> {
+        game_mode.validate_players_per_team(*settings.players_per_team())?;
+
+        Ok(Self {
             id: Uuid::new_v4(),
             date,
             settings,
             available_courts,
+            game_mode,
             player_ids: Vec::new(),
             created_at: Utc::now(),
             updated_at: None,
-        }
+        })
     }
 
     pub fn set_date(&mut self, date: NaiveDate) {
@@ -61,14 +97,26 @@ impl Session {
         self.updated_at = Some(Utc::now());
     }
 
-    pub fn set_settings(&mut self, settings: SessionSettings) {
+    pub fn set_settings(&mut self, settings: SessionSettings) -> HttpResult<()> {
+        self.game_mode
+            .validate_players_per_team(*settings.players_per_team())?;
         self.settings = settings;
         self.updated_at = Some(Utc::now());
+
+        Ok(())
     }
 
     pub fn set_available_courts(&mut self, available_courts: u8) {
         self.available_courts = available_courts;
         self.updated_at = Some(Utc::now());
+    }
+
+    pub fn set_game_mode(&mut self, game_mode: GameMode) -> HttpResult<()> {
+        game_mode.validate_players_per_team(*self.settings.players_per_team())?;
+        self.game_mode = game_mode;
+        self.updated_at = Some(Utc::now());
+
+        Ok(())
     }
 
     pub fn set_player_ids(&mut self, player_ids: Vec<Uuid>) {
@@ -83,8 +131,60 @@ getters! {
         date: NaiveDate,
         settings: SessionSettings,
         available_courts: u8,
+        game_mode: GameMode,
         player_ids: Vec<Uuid>,
         created_at: DateTime<Utc>,
         updated_at: Option<DateTime<Utc>>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_error::HttpErrorKind;
+
+    use super::*;
+
+    fn date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
+    }
+
+    #[test]
+    fn test_new_session_rejects_mixed_mode_with_odd_players_per_team() {
+        let mut settings = SessionSettings::default();
+        settings.players_per_team = 3;
+
+        let err = Session::new(date(), settings, 2, GameMode::Mixed).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_new_session_allows_mixed_mode_with_even_players_per_team() {
+        let session = Session::new(date(), SessionSettings::default(), 2, GameMode::Mixed);
+
+        assert!(session.is_ok());
+    }
+
+    #[test]
+    fn test_set_game_mode_rejects_mixed_when_current_settings_are_odd() {
+        let mut settings = SessionSettings::default();
+        settings.players_per_team = 3;
+        let mut session = Session::new(date(), settings, 2, GameMode::Male).unwrap();
+
+        let err = session.set_game_mode(GameMode::Mixed).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_set_settings_rejects_odd_players_per_team_when_mode_is_mixed() {
+        let mut session =
+            Session::new(date(), SessionSettings::default(), 2, GameMode::Mixed).unwrap();
+        let mut odd_settings = SessionSettings::default();
+        odd_settings.players_per_team = 3;
+
+        let err = session.set_settings(odd_settings).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
     }
 }

--- a/api/src/modules/matchmaking/domain/session.rs
+++ b/api/src/modules/matchmaking/domain/session.rs
@@ -15,12 +15,16 @@ pub enum GameMode {
 }
 
 impl GameMode {
+    pub fn is_mixed(&self) -> bool {
+        *self == GameMode::Mixed
+    }
+
     /// `Mixed` needs to split `players_per_team` evenly between men and
     /// women, so it only makes sense for an even count. Checked here, at the
     /// Session boundary, so a Session can never be saved in a configuration
     /// that a later team draw would be unable to honor.
     pub fn validate_players_per_team(&self, players_per_team: u8) -> HttpResult<()> {
-        if *self == GameMode::Mixed && !players_per_team.is_multiple_of(2) {
+        if self.is_mixed() && !players_per_team.is_multiple_of(2) {
             return Err(Box::new(HttpError::bad_request(
                 "Mixed game mode requires an even number of players per team",
             )));

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -2,9 +2,15 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 use http_error::{HttpError, HttpResult};
+use rand::{seq::SliceRandom, thread_rng};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
+
+use crate::modules::matchmaking::domain::{
+    player::{Gender, Player},
+    session::GameMode,
+};
 
 /// A pair/team formed from the players confirmed in a `Session`,
 /// used to compose that day's matches.
@@ -98,6 +104,87 @@ impl TeamValidator {
         }
 
         Ok(())
+    }
+}
+
+/// Randomly forms teams out of a session's confirmed players, honoring the
+/// session's `GameMode` filter. Used for a session's first draw, when there
+/// is no history yet to balance teams by; later draws may layer other
+/// criteria on top (see matchmaking-business-rules skill).
+pub struct TeamDrawer {
+    game_mode: GameMode,
+    players_per_team: u8,
+}
+
+impl TeamDrawer {
+    pub fn new(game_mode: GameMode, players_per_team: u8) -> Self {
+        Self {
+            game_mode,
+            players_per_team,
+        }
+    }
+
+    /// Returns as many full teams as can be formed from `players`, each a
+    /// list of player ids. Players left over (not enough to fill one more
+    /// team, or of the gender not needed to complete a mixed team) are
+    /// simply not included in any group.
+    pub fn draw(&self, players: &[Player]) -> HttpResult<Vec<Vec<Uuid>>> {
+        if self.players_per_team == 0 {
+            return Err(Box::new(HttpError::bad_request(
+                "Session settings must have at least one player per team",
+            )));
+        }
+        self.game_mode
+            .validate_players_per_team(self.players_per_team)?;
+
+        match self.game_mode {
+            GameMode::Male => Ok(self.draw_single_gender(players, Gender::Male)),
+            GameMode::Female => Ok(self.draw_single_gender(players, Gender::Female)),
+            GameMode::Mixed => Ok(self.draw_mixed(players)),
+        }
+    }
+
+    fn draw_single_gender(&self, players: &[Player], gender: Gender) -> Vec<Vec<Uuid>> {
+        let mut pool = Self::player_ids_of_gender(players, gender);
+        pool.shuffle(&mut thread_rng());
+
+        Self::chunk_into_teams(&pool, self.players_per_team as usize)
+    }
+
+    fn draw_mixed(&self, players: &[Player]) -> Vec<Vec<Uuid>> {
+        let players_per_gender = (self.players_per_team / 2) as usize;
+
+        let mut males = Self::player_ids_of_gender(players, Gender::Male);
+        let mut females = Self::player_ids_of_gender(players, Gender::Female);
+        males.shuffle(&mut thread_rng());
+        females.shuffle(&mut thread_rng());
+
+        let team_count = (males.len() / players_per_gender).min(females.len() / players_per_gender);
+
+        (0..team_count)
+            .map(|i| {
+                let start = i * players_per_gender;
+                let end = start + players_per_gender;
+
+                let mut team = males[start..end].to_vec();
+                team.extend_from_slice(&females[start..end]);
+                team
+            })
+            .collect()
+    }
+
+    fn player_ids_of_gender(players: &[Player], gender: Gender) -> Vec<Uuid> {
+        players
+            .iter()
+            .filter(|player| *player.gender() == gender)
+            .map(|player| *player.id())
+            .collect()
+    }
+
+    fn chunk_into_teams(pool: &[Uuid], players_per_team: usize) -> Vec<Vec<Uuid>> {
+        pool.chunks_exact(players_per_team)
+            .map(|chunk| chunk.to_vec())
+            .collect()
     }
 }
 
@@ -201,5 +288,110 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    fn player(gender: Gender) -> Player {
+        Player::new("Player".to_string(), gender)
+    }
+
+    #[test]
+    fn test_draw_male_mode_only_pairs_male_players() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+            player(Gender::Female),
+        ];
+        let male_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Male)
+            .map(|player| *player.id())
+            .collect();
+
+        let teams = TeamDrawer::new(GameMode::Male, 2).draw(&players).unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 2);
+            assert!(team.iter().all(|id| male_ids.contains(id)));
+        }
+    }
+
+    #[test]
+    fn test_draw_female_mode_leaves_leftover_player_unassigned() {
+        let players = vec![
+            player(Gender::Female),
+            player(Gender::Female),
+            player(Gender::Female),
+            player(Gender::Male),
+        ];
+
+        let teams = TeamDrawer::new(GameMode::Female, 2).draw(&players).unwrap();
+
+        assert_eq!(teams.len(), 1);
+        assert_eq!(teams[0].len(), 2);
+    }
+
+    #[test]
+    fn test_draw_mixed_mode_pairs_one_man_and_one_woman_per_team() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+            player(Gender::Female),
+        ];
+        let male_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Male)
+            .map(|player| *player.id())
+            .collect();
+        let female_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Female)
+            .map(|player| *player.id())
+            .collect();
+
+        let teams = TeamDrawer::new(GameMode::Mixed, 2).draw(&players).unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 2);
+            assert_eq!(team.iter().filter(|id| male_ids.contains(id)).count(), 1);
+            assert_eq!(team.iter().filter(|id| female_ids.contains(id)).count(), 1);
+        }
+    }
+
+    #[test]
+    fn test_draw_mixed_mode_limited_by_smaller_gender_pool() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+        ];
+
+        let teams = TeamDrawer::new(GameMode::Mixed, 2).draw(&players).unwrap();
+
+        assert_eq!(teams.len(), 1);
+    }
+
+    #[test]
+    fn test_draw_rejects_zero_players_per_team() {
+        let err = TeamDrawer::new(GameMode::Male, 0).draw(&[]).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_draw_mixed_rejects_odd_players_per_team() {
+        let players = vec![player(Gender::Male), player(Gender::Female)];
+
+        let err = TeamDrawer::new(GameMode::Mixed, 3)
+            .draw(&players)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
     }
 }

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -148,11 +148,13 @@ impl TeamDrawer {
         let mut pool = Self::player_ids_of_gender(players, gender);
         pool.shuffle(&mut thread_rng());
 
-        Self::chunk_into_teams(&pool, self.players_per_team as usize)
+        let players_per_team: usize = self.players_per_team.into();
+        Self::chunk_into_teams(&pool, players_per_team)
     }
 
     fn draw_mixed(&self, players: &[Player]) -> Vec<Vec<Uuid>> {
-        let players_per_gender = (self.players_per_team / 2) as usize;
+        let players_per_team: usize = self.players_per_team.into();
+        let players_per_gender = players_per_team / 2;
 
         let mut males = Self::player_ids_of_gender(players, Gender::Male);
         let mut females = Self::player_ids_of_gender(players, Gender::Female);

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -110,7 +110,7 @@ impl TeamValidator {
 /// Randomly forms teams out of a session's confirmed players, honoring the
 /// session's `GameMode` filter. Used for a session's first draw, when there
 /// is no history yet to balance teams by; later draws may layer other
-/// criteria on top (see matchmaking-business-rules skill).
+/// criteria on top.
 pub struct TeamDrawer {
     game_mode: GameMode,
     players_per_team: u8,

--- a/api/src/modules/matchmaking/handler/session.rs
+++ b/api/src/modules/matchmaking/handler/session.rs
@@ -35,7 +35,8 @@ impl SessionHandler for SessionHandlerImpl {
             request.date,
             request.settings.unwrap_or_default(),
             request.available_courts,
-        );
+            request.game_mode,
+        )?;
 
         self.session_repository.insert(session).await
     }
@@ -59,11 +60,15 @@ impl SessionHandler for SessionHandlerImpl {
         }
 
         if let Some(settings) = request.settings {
-            session.set_settings(settings);
+            session.set_settings(settings)?;
         }
 
         if let Some(available_courts) = request.available_courts {
             session.set_available_courts(available_courts);
+        }
+
+        if let Some(game_mode) = request.game_mode {
+            session.set_game_mode(game_mode)?;
         }
 
         if let Some(player_ids) = request.player_ids {
@@ -79,13 +84,14 @@ pub mod use_cases {
     use serde::{Deserialize, Serialize};
     use uuid::Uuid;
 
-    use crate::modules::matchmaking::domain::session::SessionSettings;
+    use crate::modules::matchmaking::domain::session::{GameMode, SessionSettings};
 
     #[derive(Debug, Clone, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CreateSessionRequest {
         pub date: NaiveDate,
         pub available_courts: u8,
+        pub game_mode: GameMode,
         pub settings: Option<SessionSettings>,
     }
 
@@ -94,6 +100,7 @@ pub mod use_cases {
     pub struct UpdateSessionRequest {
         pub date: Option<NaiveDate>,
         pub available_courts: Option<u8>,
+        pub game_mode: Option<GameMode>,
         pub settings: Option<SessionSettings>,
         pub player_ids: Option<Vec<Uuid>>,
     }

--- a/api/src/modules/matchmaking/handler/team.rs
+++ b/api/src/modules/matchmaking/handler/team.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use http_error::HttpResult;
+use http_error::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::{
-    domain::team::{Team, TeamValidator},
+    domain::team::{Team, TeamDrawer, TeamValidator},
     handler::team::use_cases::CreateTeamRequest,
-    repository::team::DynTeamRepository,
+    repository::{
+        player::DynPlayerRepository, session::DynSessionRepository, team::DynTeamRepository,
+    },
 };
 
 #[async_trait]
@@ -15,6 +17,11 @@ pub trait TeamHandler {
     async fn create_team(&self, request: CreateTeamRequest) -> HttpResult<Team>;
 
     async fn list_teams_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Team>>;
+
+    /// First draw of teams for a session: random pairing of the session's
+    /// confirmed players, honoring the session's `GameMode` filter. Fails if
+    /// the session already has teams, since it's meant to initialize them.
+    async fn draw_teams(&self, session_id: Uuid) -> HttpResult<Vec<Team>>;
 }
 
 pub type DynTeamHandler = dyn TeamHandler + Send + Sync;
@@ -22,6 +29,8 @@ pub type DynTeamHandler = dyn TeamHandler + Send + Sync;
 #[derive(Clone)]
 pub struct TeamHandlerImpl {
     pub team_repository: Arc<DynTeamRepository>,
+    pub session_repository: Arc<DynSessionRepository>,
+    pub player_repository: Arc<DynPlayerRepository>,
 }
 
 #[async_trait]
@@ -42,6 +51,51 @@ impl TeamHandler for TeamHandlerImpl {
 
     async fn list_teams_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Team>> {
         self.team_repository.list_by_session(&session_id).await
+    }
+
+    async fn draw_teams(&self, session_id: Uuid) -> HttpResult<Vec<Team>> {
+        let existing_teams = self.team_repository.list_by_session(&session_id).await?;
+        if !existing_teams.is_empty() {
+            return Err(Box::new(HttpError::conflict(
+                "Session already has teams drawn",
+            )));
+        }
+
+        let session = self
+            .session_repository
+            .get(&session_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Session", session_id)))?;
+
+        let session_players: Vec<_> = self
+            .player_repository
+            .list()
+            .await?
+            .into_iter()
+            .filter(|player| session.player_ids().contains(player.id()))
+            .collect();
+
+        let drawn_teams =
+            TeamDrawer::new(*session.game_mode(), *session.settings().players_per_team())
+                .draw(&session_players)?;
+
+        if drawn_teams.is_empty() {
+            return Err(Box::new(HttpError::bad_request(
+                "Not enough players to form a team with the session's game mode",
+            )));
+        }
+
+        let validator = TeamValidator::new(session_id);
+        let mut created_teams = Vec::with_capacity(drawn_teams.len());
+
+        for player_ids in drawn_teams {
+            validator.validate_new_team(&created_teams, &player_ids)?;
+
+            let team = Team::new(session_id, player_ids);
+            created_teams.push(self.team_repository.insert(team).await?);
+        }
+
+        Ok(created_teams)
     }
 }
 

--- a/api/src/modules/matchmaking/routes/team.rs
+++ b/api/src/modules/matchmaking/routes/team.rs
@@ -14,7 +14,8 @@ pub fn configure_routes() -> Router<AppState> {
         "/teams",
         Router::new()
             .route("/", post(create_team))
-            .route("/{session_id}", get(list_teams_by_session)),
+            .route("/{session_id}", get(list_teams_by_session))
+            .route("/{session_id}/draw", post(draw_teams)),
     )
 }
 
@@ -39,6 +40,19 @@ async fn list_teams_by_session(
         .matchmaking_state
         .team_handler
         .list_teams_by_session(session_id)
+        .await?;
+
+    Ok(Json(teams))
+}
+
+async fn draw_teams(
+    state: State<AppState>,
+    Path(session_id): Path<Uuid>,
+) -> HttpResult<impl IntoResponse> {
+    let teams = state
+        .matchmaking_state
+        .team_handler
+        .draw_teams(session_id)
         .await?;
 
     Ok(Json(teams))


### PR DESCRIPTION
Session now carries a GameMode (Male/Female/Mixed) that constrains how teams are paired: single-gender for Male/Female, 1 man + 1 woman per team for Mixed. Adds POST /matchmaking/teams/{session_id}/draw, which runs the session's first (random) team draw from its confirmed players, respecting that filter; blocked if the session already has teams, since it's meant to initialize them once.

GameMode/players_per_team consistency (Mixed needs an even count) is validated both when a Session is created/updated and at draw time, so a Session can never be saved in a configuration the draw can't honor.