### PR TITLE
feat(matchmaking): model in-progress Match with a result-report endpoint

### DIFF
--- a/.claude/skills/matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/matchmaking-business-rules/SKILL.md
@@ -46,6 +46,16 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
 - `draw_teams` só pode ser chamado uma vez por `Session` (é o sorteio de
   *inicialização*): se a `Session` já tiver alguma `Team`, retorna
   `HttpError::conflict`. Não existe hoje endpoint para resetar/re-sortear.
+- Um `Match` não pode ter as duas equipes iguais (`team_a_id != team_b_id`).
+- O resultado de um `Match` só pode ser reportado uma vez: reportar de novo
+  um `Match` que já tem `winner_team_id` retorna `HttpError::conflict`.
+- `winner_team_id` reportado precisa ser `team_a_id` ou `team_b_id` do
+  próprio `Match`; qualquer outro valor retorna `HttpError::bad_request`.
+
+Validado por `Match::new`/`Match::finish`
+(`api/src/modules/matchmaking/domain/matches.rs`), chamados por
+`MatchHandlerImpl::create_match`/`report_match_result` via `POST
+/matchmaking/matches/` e `POST /matchmaking/matches/{match_id}/result`.
 
 Restrições de duplicidade de jogador validadas por
 `TeamValidator::validate_new_team` (`api/src/modules/matchmaking/domain/team.rs`),
@@ -86,8 +96,27 @@ Session sem jogadores suficientes para as quadras disponíveis, jogador
 removido de uma Session após os times já terem sido sorteados, etc.
 -->
 
+## Casos-limite conhecidos (continuação)
+
+- Ainda não existe checagem de que `team_a_id`/`team_b_id` de um `Match`
+  pertencem de fato a `Team`s da `Session` informada, nem de que uma
+  `Team`/quadra não tenha mais de um `Match` em andamento simultaneamente.
+  Estrutura inicial deliberadamente simples (só o estado
+  em-andamento → resultado reportado); regras de "o que sortear a seguir
+  quando uma partida termina" ainda serão definidas e documentadas aqui
+  conforme forem implementadas.
+
 ## Histórico de mudanças
 
+- 2026-08-04 — `Match` passa a nascer sem resultado (`winner_team_id`/
+  `played_at` como `Option`, partida "em andamento" na quadra) via `POST
+  /matchmaking/matches/`; novo endpoint `POST
+  /matchmaking/matches/{match_id}/result` reporta o resultado
+  (`ReportMatchResultRequest { winner_team_id }`), validando que a partida
+  ainda não tem resultado e que o vencedor é uma das duas equipes do
+  `Match`. Primeira peça da estrutura de "regras de sorteio conforme os
+  jogos vão finalizando" — regras de qual será o próximo sorteio após um
+  resultado ainda serão decididas e adicionadas aqui.
 - 2026-08-04 — implementada validação em `create_team`: rejeita jogador
   duplicado dentro da mesma `Team` (`HttpError::bad_request`) e jogador já
   presente em outra `Team` da mesma `Session` (`HttpError::conflict`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ sqlx migrate add --source migrations/<domínio> nome_da_migration
 
 Cada módulo/domínio segue o padrão `domain / handler / repository / routes`:
 
-- **`domain/`** — structs do modelo (ex: `User`, `Debt`), sem lógica de infra.
+- **`domain/`** — structs do modelo (ex: `User`, `Debt`), sem lógica de infra. Condições booleanas usadas para validação/regra de negócio (ex: "esse `winner_team_id` é um dos times do `Match`?") devem ser extraídas como método nomeado na própria struct (ex: `Match::has_team`, `Match::is_finished`), não deixadas como expressão inline dentro de outro método. Quando a validação envolver múltiplos passos ou precisar de um valor de escopo (ex: `session_id`), usar uma struct validadora dedicada com esse valor vinculado na construção (ex: `TeamValidator::new(session_id)`) em vez de funções soltas no módulo.
 - **`repository/`** — trait `DynXRepository` + impl (`XRepositoryImpl`) que recebe `&Pool<Postgres>` e faz as queries via `sqlx`.
 - **`handler/`** — trait `XHandler` (`#[async_trait]`) + impl (`XHandlerImpl`) que orquestra regra de negócio, chamando o repository. É o que fica dentro do `AppState`, sempre atrás de `Arc<...>`.
 - **`routes/`** — funções `async fn` que recebem `State<AppState>` + `Json`/`Path`/`HeaderMap`, chamam o handler e retornam `HttpResult<impl IntoResponse>`. `configure_routes()`/`configure_service_routes()` monta o `Router<AppState>` do módulo.

--- a/api/src/modules/matchmaking/domain/matches.rs
+++ b/api/src/modules/matchmaking/domain/matches.rs
@@ -44,6 +44,11 @@ impl Match {
         self.winner_team_id.is_some()
     }
 
+    /// Whether `team_id` is one of the two teams playing this match.
+    pub fn has_team(&self, team_id: Uuid) -> bool {
+        team_id == self.team_a_id || team_id == self.team_b_id
+    }
+
     /// Records the result of this in-progress match. Fails if a result was
     /// already reported, or if `winner_team_id` isn't one of the two teams
     /// that played it.
@@ -54,7 +59,7 @@ impl Match {
             )));
         }
 
-        if winner_team_id != self.team_a_id && winner_team_id != self.team_b_id {
+        if !self.has_team(winner_team_id) {
             return Err(Box::new(HttpError::bad_request(
                 "winner_team_id must be one of the match's two teams",
             )));

--- a/api/src/modules/matchmaking/domain/matches.rs
+++ b/api/src/modules/matchmaking/domain/matches.rs
@@ -1,10 +1,12 @@
 use chrono::{DateTime, Utc};
+use http_error::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
 
-/// Record of a match that already happened: court, teams involved and
-/// the winning team.
+/// A match assigned to a court: the two teams facing off, and the result
+/// once it's been reported. `winner_team_id`/`played_at` are `None` while
+/// the match is still in progress on the court.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Match {
@@ -13,27 +15,55 @@ pub struct Match {
     court: u8,
     team_a_id: Uuid,
     team_b_id: Uuid,
-    winner_team_id: Uuid,
-    played_at: DateTime<Utc>,
+    winner_team_id: Option<Uuid>,
+    started_at: DateTime<Utc>,
+    played_at: Option<DateTime<Utc>>,
 }
 
 impl Match {
-    pub fn new(
-        session_id: Uuid,
-        court: u8,
-        team_a_id: Uuid,
-        team_b_id: Uuid,
-        winner_team_id: Uuid,
-    ) -> Self {
-        Self {
+    pub fn new(session_id: Uuid, court: u8, team_a_id: Uuid, team_b_id: Uuid) -> HttpResult<Self> {
+        if team_a_id == team_b_id {
+            return Err(Box::new(HttpError::bad_request(
+                "A team cannot play against itself",
+            )));
+        }
+
+        Ok(Self {
             id: Uuid::new_v4(),
             session_id,
             court,
             team_a_id,
             team_b_id,
-            winner_team_id,
-            played_at: Utc::now(),
+            winner_team_id: None,
+            started_at: Utc::now(),
+            played_at: None,
+        })
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.winner_team_id.is_some()
+    }
+
+    /// Records the result of this in-progress match. Fails if a result was
+    /// already reported, or if `winner_team_id` isn't one of the two teams
+    /// that played it.
+    pub fn finish(&mut self, winner_team_id: Uuid) -> HttpResult<()> {
+        if self.is_finished() {
+            return Err(Box::new(HttpError::conflict(
+                "Match already has a recorded result",
+            )));
         }
+
+        if winner_team_id != self.team_a_id && winner_team_id != self.team_b_id {
+            return Err(Box::new(HttpError::bad_request(
+                "winner_team_id must be one of the match's two teams",
+            )));
+        }
+
+        self.winner_team_id = Some(winner_team_id);
+        self.played_at = Some(Utc::now());
+
+        Ok(())
     }
 }
 
@@ -44,7 +74,69 @@ getters! {
         court: u8,
         team_a_id: Uuid,
         team_b_id: Uuid,
-        winner_team_id: Uuid,
-        played_at: DateTime<Utc>,
+        winner_team_id: Option<Uuid>,
+        started_at: DateTime<Utc>,
+        played_at: Option<DateTime<Utc>>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_error::HttpErrorKind;
+
+    use super::*;
+
+    fn new_match() -> Match {
+        Match::new(Uuid::new_v4(), 1, Uuid::new_v4(), Uuid::new_v4()).unwrap()
+    }
+
+    #[test]
+    fn test_new_rejects_team_playing_against_itself() {
+        let team_id = Uuid::new_v4();
+
+        let err = Match::new(Uuid::new_v4(), 1, team_id, team_id).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_new_match_starts_unfinished() {
+        let match_ = new_match();
+
+        assert!(!match_.is_finished());
+        assert!(match_.winner_team_id().is_none());
+        assert!(match_.played_at().is_none());
+    }
+
+    #[test]
+    fn test_finish_records_winner_and_played_at() {
+        let mut match_ = new_match();
+        let winner = *match_.team_a_id();
+
+        match_.finish(winner).unwrap();
+
+        assert!(match_.is_finished());
+        assert_eq!(match_.winner_team_id(), &Some(winner));
+        assert!(match_.played_at().is_some());
+    }
+
+    #[test]
+    fn test_finish_rejects_winner_outside_the_match() {
+        let mut match_ = new_match();
+
+        let err = match_.finish(Uuid::new_v4()).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_finish_rejects_reporting_result_twice() {
+        let mut match_ = new_match();
+        let winner = *match_.team_a_id();
+        match_.finish(winner).unwrap();
+
+        let err = match_.finish(winner).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
     }
 }

--- a/api/src/modules/matchmaking/handler/matches.rs
+++ b/api/src/modules/matchmaking/handler/matches.rs
@@ -1,19 +1,29 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use http_error::HttpResult;
+use http_error::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::{
-    domain::matches::Match, handler::matches::use_cases::CreateMatchRequest,
+    domain::matches::Match,
+    handler::matches::use_cases::{CreateMatchRequest, ReportMatchResultRequest},
     repository::matches::DynMatchRepository,
 };
 
 #[async_trait]
 pub trait MatchHandler {
+    /// Starts a match on a court: assigns the two teams facing off, with no
+    /// result yet.
     async fn create_match(&self, request: CreateMatchRequest) -> HttpResult<Match>;
 
     async fn list_matches_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Match>>;
+
+    /// Reports the result of a match that's in progress on a court.
+    async fn report_match_result(
+        &self,
+        match_id: Uuid,
+        request: ReportMatchResultRequest,
+    ) -> HttpResult<Match>;
 }
 
 pub type DynMatchHandler = dyn MatchHandler + Send + Sync;
@@ -31,14 +41,29 @@ impl MatchHandler for MatchHandlerImpl {
             request.court,
             request.team_a_id,
             request.team_b_id,
-            request.winner_team_id,
-        );
+        )?;
 
         self.match_repository.insert(match_).await
     }
 
     async fn list_matches_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Match>> {
         self.match_repository.list_by_session(&session_id).await
+    }
+
+    async fn report_match_result(
+        &self,
+        match_id: Uuid,
+        request: ReportMatchResultRequest,
+    ) -> HttpResult<Match> {
+        let mut match_ = self
+            .match_repository
+            .get(&match_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Match", match_id)))?;
+
+        match_.finish(request.winner_team_id)?;
+
+        self.match_repository.update(match_).await
     }
 }
 
@@ -53,6 +78,11 @@ pub mod use_cases {
         pub court: u8,
         pub team_a_id: Uuid,
         pub team_b_id: Uuid,
+    }
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ReportMatchResultRequest {
         pub winner_team_id: Uuid,
     }
 }

--- a/api/src/modules/matchmaking/repository/matches.rs
+++ b/api/src/modules/matchmaking/repository/matches.rs
@@ -11,6 +11,10 @@ pub trait MatchRepository {
     async fn insert(&self, match_: Match) -> HttpResult<Match>;
 
     async fn list_by_session(&self, session_id: &Uuid) -> HttpResult<Vec<Match>>;
+
+    async fn get(&self, id: &Uuid) -> HttpResult<Option<Match>>;
+
+    async fn update(&self, match_: Match) -> HttpResult<Match>;
 }
 
 pub type DynMatchRepository = dyn MatchRepository + Send + Sync;
@@ -45,5 +49,18 @@ impl MatchRepository for InMemoryMatchRepository {
             .filter(|match_| match_.session_id() == session_id)
             .cloned()
             .collect())
+    }
+
+    async fn get(&self, id: &Uuid) -> HttpResult<Option<Match>> {
+        let matches = self.matches.lock().expect("match repository lock poisoned");
+
+        Ok(matches.get(id).cloned())
+    }
+
+    async fn update(&self, match_: Match) -> HttpResult<Match> {
+        let mut matches = self.matches.lock().expect("match repository lock poisoned");
+        matches.insert(*match_.id(), match_.clone());
+
+        Ok(match_)
     }
 }

--- a/api/src/modules/matchmaking/routes/matches.rs
+++ b/api/src/modules/matchmaking/routes/matches.rs
@@ -7,14 +7,18 @@ use axum::{
 use http_error::HttpResult;
 use uuid::Uuid;
 
-use crate::modules::{matchmaking::handler::matches::use_cases::CreateMatchRequest, routes::AppState};
+use crate::modules::{
+    matchmaking::handler::matches::use_cases::{CreateMatchRequest, ReportMatchResultRequest},
+    routes::AppState,
+};
 
 pub fn configure_routes() -> Router<AppState> {
     Router::new().nest(
         "/matches",
         Router::new()
             .route("/", post(create_match))
-            .route("/{session_id}", get(list_matches_by_session)),
+            .route("/{session_id}", get(list_matches_by_session))
+            .route("/{match_id}/result", post(report_match_result)),
     )
 }
 
@@ -42,4 +46,18 @@ async fn list_matches_by_session(
         .await?;
 
     Ok(Json(matches))
+}
+
+async fn report_match_result(
+    state: State<AppState>,
+    Path(match_id): Path<Uuid>,
+    Json(request): Json<ReportMatchResultRequest>,
+) -> HttpResult<impl IntoResponse> {
+    let match_ = state
+        .matchmaking_state
+        .match_handler
+        .report_match_result(match_id, request)
+        .await?;
+
+    Ok(Json(match_))
 }


### PR DESCRIPTION
Match now starts on a court without a winner (started_at set, winner_team_id/played_at None). A new POST /matchmaking/matches/{match_id}/result endpoint closes it out via Match::finish, rejecting a winner outside the match's two teams or a second result on an already-finished match. Basic structure to build the post-result draw rules on top of.