### PR TITLE
feat(matchmaking): continuous team queue with win-streak court rotation

### DIFF
--- a/.claude/skills/gb-matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/gb-matchmaking-business-rules/SKILL.md
@@ -18,13 +18,21 @@ description: Regras de negócio do módulo de matchmaking — critérios de pare
   mesmo gênero; `Mixed` forma cada `Team` com metade dos jogadores homens e
   metade mulheres (com `players_per_team = 2`, na prática 1 homem + 1
   mulher).
-- O primeiro sorteio de `Team`s de uma `Session` é aleatório, sem nenhum
-  critério de balanceamento (nível, histórico de parceria, etc.) — v1
-  deliberadamente simples, pois no início da sessão não há histórico para
-  balancear. Sorteios futuros podem somar outros critérios em cima do
-  `GameMode`.
-- Implementado por `TeamDrawer::draw` (`api/src/modules/matchmaking/domain/team.rs`),
-  chamado por `TeamHandlerImpl::draw_teams` via `POST
+- O sorteio (tanto o inicial quanto os que acontecem conforme partidas
+  terminam) evita, best-effort, formar uma `Team` com dois jogadores que já
+  jogaram juntos como parceiros na mesma `Session` — mas aceita repetir se
+  não houver alternativa (nunca trava o sorteio por causa disso). O
+  histórico usado é só de `Team`s que de fato entraram em algum `Match`;
+  uma dupla que só passou pela fila sem chegar a jogar não conta.
+  Implementado por `PartnerHistory` + o algoritmo greedy
+  most-constrained-first de `TeamDrawer::draw`
+  (`api/src/modules/matchmaking/domain/team_drawer.rs`).
+- Jogadores que sobram (não fecham um time cheio, ou, no modo `Mixed`, são
+  do gênero já esgotado) nunca são descartados: formam uma `Team`
+  incompleta, visível via `GET /matchmaking/teams/{session_id}`, esperando
+  outro jogador ser liberado para completá-la.
+- Implementado por `TeamDrawer::draw` (sorteio inicial, sem histórico) e por
+  `TeamHandlerImpl::draw_teams` via `POST
   /matchmaking/teams/{session_id}/draw`.
 
 <!--
@@ -32,6 +40,42 @@ Como jogadores são agrupados em duplas/times (Team) e como partidas
 (Match) são formadas a partir das duplas de uma Session. Ex: nível de
 habilidade, histórico de parceria, aleatoriedade controlada, etc.
 -->
+
+### Fila e rotação de quadra
+
+- Uma `Team` tem um `status`: `Waiting` (na fila, disponível pra entrar em
+  quadra), `Holding` (venceu e está segurando a quadra aguardando o próximo
+  desafiante) ou `Disbanded` (perdeu, ou girou pra fora por ter batido o
+  cap de vitórias — jogadores livres, registro mantido só como histórico de
+  parceria).
+- **Vencedor:** ao vencer, a `Team` fica segurando a quadra e joga mais uma
+  (`Team::register_win`, `status = Holding`). Se vencer essa também (2
+  vitórias seguidas na mesma quadra — `MAX_CONSECUTIVE_WINS`), ela também é
+  desfeita: seus jogadores voltam pra fila igual a um time perdedor, e a
+  quadra precisa de duas `Team`s novas da fila.
+- **Perdedor:** sempre se desfaz (`Team::disband`); seus jogadores voltam
+  pra fila.
+- **Fila (FIFO):** jogadores liberados (do perdedor, e do vencedor quando
+  bate o cap) são inseridos na fila em ordem aleatória — cada um tenta
+  completar uma `Team` incompleta compatível (mesmo gênero necessário, no
+  caso `Mixed`) já esperando na fila; se não achar, inicia uma nova `Team`
+  incompleta. Sem regra especial de "qual dos jogadores liberados" completa
+  a sobra existente. Implementado por `TeamQueueManager::release_players`
+  (`api/src/modules/matchmaking/domain/team_queue.rs`).
+- **Continuação automática da quadra:** ao reportar o resultado de um
+  `Match` (`POST /matchmaking/matches/{match_id}/result`), o sistema já
+  cria automaticamente o próximo `Match` daquela quadra — vencedor (se
+  ainda segurando) contra o primeiro time completo da fila
+  (`TeamQueueManager::next_complete_teams`), ou duas `Team`s novas da fila
+  se o vencedor também girou. Não é preciso chamar `POST
+  /matchmaking/matches/` de novo pra continuar uma quadra já ocupada — esse
+  endpoint só serve pra abrir uma quadra pela primeira vez. Se a fila ainda
+  não tiver `Team`s completas suficientes, a quadra fica ociosa até ter
+  (não é tratado como erro).
+- Orquestrado por `TeamHandlerImpl::resolve_match_result`
+  (`api/src/modules/matchmaking/handler/team.rs`), chamado por
+  `MatchHandlerImpl::report_match_result`
+  (`api/src/modules/matchmaking/handler/matches.rs`).
 
 ## Restrições
 
@@ -45,14 +89,21 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
   configuração que o sorteio não consegue honrar.
 - `draw_teams` só pode ser chamado uma vez por `Session` (é o sorteio de
   *inicialização*): se a `Session` já tiver alguma `Team`, retorna
-  `HttpError::conflict`. Não existe hoje endpoint para resetar/re-sortear.
+  `HttpError::conflict`. Não existe hoje endpoint para resetar/re-sortear
+  do zero (a fila segue evoluindo sozinha depois, via resultado de partida).
 - Um `Match` não pode ter as duas equipes iguais (`team_a_id != team_b_id`).
 - O resultado de um `Match` só pode ser reportado uma vez: reportar de novo
   um `Match` que já tem `winner_team_id` retorna `HttpError::conflict`.
 - `winner_team_id` reportado precisa ser `team_a_id` ou `team_b_id` do
   próprio `Match`; qualquer outro valor retorna `HttpError::bad_request`.
+- Para iniciar um `Match` (`POST /matchmaking/matches/`), as duas `Team`s
+  precisam: pertencer à `Session` informada, estar completas
+  (`Team::is_complete`, não uma sobra esperando parceiro), não estar
+  `Disbanded`, e não estar já disputando outro `Match` em andamento em
+  outra quadra (`Match::busy_team_ids`). Validado por
+  `MatchStartValidator::validate_start`.
 
-Validado por `Match::new`/`Match::finish`
+Validado por `Match::new`/`Match::finish`/`MatchStartValidator`
 (`api/src/modules/matchmaking/domain/matches.rs`), chamados por
 `MatchHandlerImpl::create_match`/`report_match_result` via `POST
 /matchmaking/matches/` e `POST /matchmaking/matches/{match_id}/result`.
@@ -79,16 +130,23 @@ Ex: balanceamento de nível tem prioridade sobre variar parceiros.
 
 ## Casos-limite conhecidos
 
-- Jogadores que sobram sem completar um time cheio (ou, no modo `Mixed`, do
-  gênero que já se esgotou) ficam de fora do sorteio silenciosamente —
-  `draw_teams` retorna só os times formados, sem indicar quem ficou de fora.
-  Ainda não decidido se isso deve mudar (ex: devolver lista de não
-  alocados).
 - `draw_teams` faz o check de "sessão já tem times" e os inserts em
   chamadas separadas ao repositório — duas chamadas concorrentes para a
   mesma `Session` podem, em teoria, passar pelo check antes de qualquer
   insert acontecer (TOCTOU). Não tratado ainda; aceitável hoje por ser
-  repositório em memória de processo único, sem carga concorrente real.
+  repositório em memória de processo único, sem carga concorrente real. O
+  mesmo vale, em tese, para `resolve_match_result`/`create_match`
+  concorrentes na mesma quadra.
+- Resolvido nesta rodada (ver Histórico de mudanças): jogadores que
+  sobravam no sorteio eram descartados silenciosamente; não havia checagem
+  de `Team` pertencente à `Session` nem de partida simultânea na mesma
+  `Team`/quadra; não existia noção do que acontece depois que um `Match`
+  termina.
+- Em `Mixed` mode, uma `Team` incompleta esperando um gênero específico só
+  é completada por um jogador liberado desse mesmo gênero
+  (`TeamQueueManager::needs_gender`) — se o desbalanceamento de gênero for
+  grande, podem se acumular várias `Team`s incompletas em paralelo (uma por
+  gênero em falta), não só uma. Comportamento aceito, não é bug.
 
 <!--
 Situações especiais já discutidas/decididas. Ex: número ímpar de jogadores,
@@ -96,18 +154,21 @@ Session sem jogadores suficientes para as quadras disponíveis, jogador
 removido de uma Session após os times já terem sido sorteados, etc.
 -->
 
-## Casos-limite conhecidos (continuação)
-
-- Ainda não existe checagem de que `team_a_id`/`team_b_id` de um `Match`
-  pertencem de fato a `Team`s da `Session` informada, nem de que uma
-  `Team`/quadra não tenha mais de um `Match` em andamento simultaneamente.
-  Estrutura inicial deliberadamente simples (só o estado
-  em-andamento → resultado reportado); regras de "o que sortear a seguir
-  quando uma partida termina" ainda serão definidas e documentadas aqui
-  conforme forem implementadas.
-
 ## Histórico de mudanças
 
+- 2026-08-07 — Fila contínua de duplas com rotação por vitórias: `Team`
+  ganha `status` (`Waiting`/`Holding`/`Disbanded`) e `consecutive_wins`.
+  Perdedor de um `Match` sempre é desfeito; vencedor segura a quadra até 2
+  vitórias seguidas, depois também é desfeito. Jogadores liberados entram
+  numa fila FIFO (`TeamQueueManager`) que nunca descarta sobra (formam
+  `Team`s incompletas) e evita, best-effort, repetir parceiros que já
+  jogaram juntos na `Session` (`PartnerHistory`, olhando só `Team`s que de
+  fato jogaram). `report_match_result` passa a criar automaticamente o
+  próximo `Match` da quadra que ficou livre, sem precisar de nova chamada
+  manual a `create_match`. `create_match` (usado só pra abrir uma quadra
+  pela primeira vez) passa a validar via `MatchStartValidator` que as duas
+  `Team`s pertencem à `Session`, estão completas, não estão `Disbanded` e
+  não estão ocupadas em outro `Match` em andamento.
 - 2026-08-04 — `Match` passa a nascer sem resultado (`winner_team_id`/
   `played_at` como `Option`, partida "em andamento" na quadra) via `POST
   /matchmaking/matches/`; novo endpoint `POST

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -132,21 +132,25 @@ fn build_matchmaking_state() -> MatchmakingState {
     let player_repository = Arc::new(InMemoryPlayerRepository::new());
     let session_repository = Arc::new(InMemorySessionRepository::new());
     let team_repository = Arc::new(InMemoryTeamRepository::new());
+    let match_repository = Arc::new(InMemoryMatchRepository::new());
+
+    let team_handler = Arc::new(TeamHandlerImpl {
+        team_repository,
+        session_repository: session_repository.clone(),
+        player_repository: player_repository.clone(),
+        match_repository: match_repository.clone(),
+    });
 
     MatchmakingState {
-        player_handler: Arc::new(PlayerHandlerImpl {
-            player_repository: player_repository.clone(),
-        }),
+        player_handler: Arc::new(PlayerHandlerImpl { player_repository }),
         session_handler: Arc::new(SessionHandlerImpl {
             session_repository: session_repository.clone(),
         }),
-        team_handler: Arc::new(TeamHandlerImpl {
-            team_repository,
-            session_repository,
-            player_repository,
-        }),
+        team_handler: team_handler.clone(),
         match_handler: Arc::new(MatchHandlerImpl {
-            match_repository: Arc::new(InMemoryMatchRepository::new()),
+            match_repository,
+            session_repository,
+            team_handler,
         }),
     }
 }

--- a/api/src/modules/matchmaking/domain.rs
+++ b/api/src/modules/matchmaking/domain.rs
@@ -2,3 +2,5 @@ pub mod matches;
 pub mod player;
 pub mod session;
 pub mod team;
+pub mod team_drawer;
+pub mod team_queue;

--- a/api/src/modules/matchmaking/domain/matches.rs
+++ b/api/src/modules/matchmaking/domain/matches.rs
@@ -1,8 +1,12 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use http_error::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
+
+use crate::modules::matchmaking::domain::team::Team;
 
 /// A match assigned to a court: the two teams facing off, and the result
 /// once it's been reported. `winner_team_id`/`played_at` are `None` while
@@ -67,6 +71,84 @@ impl Match {
 
         self.winner_team_id = Some(winner_team_id);
         self.played_at = Some(Utc::now());
+
+        Ok(())
+    }
+
+    /// The ids of every team currently tied up in an in-progress match,
+    /// across any court — used to keep a team from being started on a
+    /// second court before its current match is reported.
+    pub fn busy_team_ids(matches: &[Match]) -> HashSet<Uuid> {
+        matches
+            .iter()
+            .filter(|match_| !match_.is_finished())
+            .flat_map(|match_| [*match_.team_a_id(), *match_.team_b_id()])
+            .collect()
+    }
+}
+
+/// Centralizes the checks for starting a match: both teams must belong to
+/// this session, be a full team (not one still waiting on a partner), still
+/// be around to play (not disbanded), and not already be busy in another
+/// in-progress match. Bound to a `session_id` and `players_per_team` at
+/// construction, same as `TeamValidator`.
+pub struct MatchStartValidator {
+    session_id: Uuid,
+    players_per_team: u8,
+}
+
+impl MatchStartValidator {
+    pub fn new(session_id: Uuid, players_per_team: u8) -> Self {
+        Self {
+            session_id,
+            players_per_team,
+        }
+    }
+
+    pub fn validate_start(
+        &self,
+        session_teams: &[Team],
+        session_matches: &[Match],
+        team_a_id: Uuid,
+        team_b_id: Uuid,
+    ) -> HttpResult<()> {
+        let busy_team_ids = Match::busy_team_ids(session_matches);
+
+        for team_id in [team_a_id, team_b_id] {
+            self.validate_team_can_start(session_teams, &busy_team_ids, team_id)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_team_can_start(
+        &self,
+        session_teams: &[Team],
+        busy_team_ids: &HashSet<Uuid>,
+        team_id: Uuid,
+    ) -> HttpResult<()> {
+        let team = session_teams
+            .iter()
+            .find(|team| *team.id() == team_id && *team.session_id() == self.session_id)
+            .ok_or_else(|| Box::new(HttpError::not_found("Team", team_id)))?;
+
+        if team.is_disbanded() {
+            return Err(Box::new(HttpError::conflict(format!(
+                "Team {team_id} has been disbanded and cannot start a match"
+            ))));
+        }
+
+        if !team.is_complete(self.players_per_team) {
+            return Err(Box::new(HttpError::conflict(format!(
+                "Team {team_id} is still waiting on a partner and cannot start a match"
+            ))));
+        }
+
+        if busy_team_ids.contains(&team_id) {
+            return Err(Box::new(HttpError::conflict(format!(
+                "Team {team_id} is already playing an in-progress match"
+            ))));
+        }
 
         Ok(())
     }
@@ -141,6 +223,113 @@ mod tests {
         match_.finish(winner).unwrap();
 
         let err = match_.finish(winner).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_busy_team_ids_only_includes_unfinished_matches() {
+        let team_a = Uuid::new_v4();
+        let team_b = Uuid::new_v4();
+        let team_c = Uuid::new_v4();
+        let team_d = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+
+        let ongoing = Match::new(session_id, 1, team_a, team_b).unwrap();
+        let mut finished = Match::new(session_id, 2, team_c, team_d).unwrap();
+        finished.finish(team_c).unwrap();
+
+        let busy = Match::busy_team_ids(&[ongoing, finished]);
+
+        assert!(busy.contains(&team_a));
+        assert!(busy.contains(&team_b));
+        assert!(!busy.contains(&team_c));
+        assert!(!busy.contains(&team_d));
+    }
+
+    fn team(session_id: Uuid) -> Team {
+        Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()])
+    }
+
+    #[test]
+    fn test_match_start_validator_accepts_waiting_teams_from_the_same_session() {
+        let session_id = Uuid::new_v4();
+        let team_a = team(session_id);
+        let team_b = team(session_id);
+        let team_a_id = *team_a.id();
+        let team_b_id = *team_b.id();
+
+        let result = MatchStartValidator::new(session_id, 2).validate_start(
+            &[team_a, team_b],
+            &[],
+            team_a_id,
+            team_b_id,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_match_start_validator_rejects_incomplete_team() {
+        let session_id = Uuid::new_v4();
+        let incomplete_team = Team::new(session_id, vec![Uuid::new_v4()]);
+        let team_b = team(session_id);
+        let team_a_id = *incomplete_team.id();
+        let team_b_id = *team_b.id();
+
+        let err = MatchStartValidator::new(session_id, 2)
+            .validate_start(&[incomplete_team, team_b], &[], team_a_id, team_b_id)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_match_start_validator_rejects_team_from_another_session() {
+        let session_id = Uuid::new_v4();
+        let team_a = team(session_id);
+        let team_b = team(Uuid::new_v4());
+        let team_a_id = *team_a.id();
+        let team_b_id = *team_b.id();
+
+        let err = MatchStartValidator::new(session_id, 2)
+            .validate_start(&[team_a, team_b], &[], team_a_id, team_b_id)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_match_start_validator_rejects_disbanded_team() {
+        let session_id = Uuid::new_v4();
+        let mut team_a = team(session_id);
+        team_a.disband();
+        let team_b = team(session_id);
+        let team_a_id = *team_a.id();
+        let team_b_id = *team_b.id();
+
+        let err = MatchStartValidator::new(session_id, 2)
+            .validate_start(&[team_a, team_b], &[], team_a_id, team_b_id)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_match_start_validator_rejects_team_already_in_an_ongoing_match() {
+        let session_id = Uuid::new_v4();
+        let team_a = team(session_id);
+        let team_b = team(session_id);
+        let team_c = team(session_id);
+        let team_a_id = *team_a.id();
+        let team_b_id = *team_b.id();
+        let team_c_id = *team_c.id();
+
+        let ongoing = Match::new(session_id, 1, team_a_id, team_b_id).unwrap();
+
+        let err = MatchStartValidator::new(session_id, 2)
+            .validate_start(&[team_a, team_b, team_c], &[ongoing], team_a_id, team_c_id)
+            .unwrap_err();
 
         assert_eq!(err.kind, HttpErrorKind::Conflict);
     }

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -2,15 +2,21 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 use http_error::{HttpError, HttpResult};
-use rand::{seq::SliceRandom, thread_rng};
 use serde::{Deserialize, Serialize};
 use util::getters;
 use uuid::Uuid;
 
-use crate::modules::matchmaking::domain::{
-    player::{Gender, Player},
-    session::GameMode,
-};
+/// A team's place in the session's rotation: `Waiting` in the queue to be
+/// called up to a court, `Holding` a court after a win (until it either
+/// loses or hits the consecutive-win cap), or `Disbanded` once it's done,
+/// freeing its players back into the queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TeamStatus {
+    Waiting,
+    Holding,
+    Disbanded,
+}
 
 /// A pair/team formed from the players confirmed in a `Session`,
 /// used to compose that day's matches.
@@ -20,16 +26,66 @@ pub struct Team {
     id: Uuid,
     session_id: Uuid,
     player_ids: Vec<Uuid>,
+    status: TeamStatus,
+    consecutive_wins: u8,
     created_at: DateTime<Utc>,
 }
 
 impl Team {
+    /// A team is rotated out after this many consecutive wins on the same
+    /// court, so other waiting teams get a turn.
+    const MAX_CONSECUTIVE_WINS: u8 = 2;
+
     pub fn new(session_id: Uuid, player_ids: Vec<Uuid>) -> Self {
         Self {
             id: Uuid::new_v4(),
             session_id,
             player_ids,
+            status: TeamStatus::Waiting,
+            consecutive_wins: 0,
             created_at: Utc::now(),
+        }
+    }
+
+    pub fn is_waiting(&self) -> bool {
+        self.status == TeamStatus::Waiting
+    }
+
+    pub fn is_holding(&self) -> bool {
+        self.status == TeamStatus::Holding
+    }
+
+    pub fn is_disbanded(&self) -> bool {
+        self.status == TeamStatus::Disbanded
+    }
+
+    /// Whether this team has as many players as a full team needs.
+    pub fn is_complete(&self, players_per_team: u8) -> bool {
+        self.player_ids.len() >= players_per_team.into()
+    }
+
+    /// Frees this team's players back into the queue: it's done, whether it
+    /// just lost or hit the consecutive-win cap. Idempotent.
+    pub fn disband(&mut self) {
+        self.status = TeamStatus::Disbanded;
+    }
+
+    /// Adds a freed player to this (presumably incomplete) waiting team,
+    /// completing it or extending how many players it still needs.
+    pub fn add_player(&mut self, player_id: Uuid) {
+        self.player_ids.push(player_id);
+    }
+
+    /// Records a win. A team keeps holding its court after a win, but only
+    /// up to `MAX_CONSECUTIVE_WINS` in a row — past that, it's disbanded
+    /// like a loss would be, so other waiting teams get a turn.
+    pub fn register_win(&mut self) {
+        self.consecutive_wins += 1;
+
+        if self.consecutive_wins >= Self::MAX_CONSECUTIVE_WINS {
+            self.disband();
+        } else {
+            self.status = TeamStatus::Holding;
         }
     }
 }
@@ -39,6 +95,8 @@ getters! {
         id: Uuid,
         session_id: Uuid,
         player_ids: Vec<Uuid>,
+        status: TeamStatus,
+        consecutive_wins: u8,
         created_at: DateTime<Utc>,
     }
 }
@@ -107,94 +165,72 @@ impl TeamValidator {
     }
 }
 
-/// Randomly forms teams out of a session's confirmed players, honoring the
-/// session's `GameMode` filter. Used for a session's first draw, when there
-/// is no history yet to balance teams by; later draws may layer other
-/// criteria on top.
-pub struct TeamDrawer {
-    game_mode: GameMode,
-    players_per_team: u8,
-}
-
-impl TeamDrawer {
-    pub fn new(game_mode: GameMode, players_per_team: u8) -> Self {
-        Self {
-            game_mode,
-            players_per_team,
-        }
-    }
-
-    /// Returns as many full teams as can be formed from `players`, each a
-    /// list of player ids. Players left over (not enough to fill one more
-    /// team, or of the gender not needed to complete a mixed team) are
-    /// simply not included in any group.
-    pub fn draw(&self, players: &[Player]) -> HttpResult<Vec<Vec<Uuid>>> {
-        if self.players_per_team == 0 {
-            return Err(Box::new(HttpError::bad_request(
-                "Session settings must have at least one player per team",
-            )));
-        }
-        self.game_mode
-            .validate_players_per_team(self.players_per_team)?;
-
-        match self.game_mode {
-            GameMode::Male => Ok(self.draw_single_gender(players, Gender::Male)),
-            GameMode::Female => Ok(self.draw_single_gender(players, Gender::Female)),
-            GameMode::Mixed => Ok(self.draw_mixed(players)),
-        }
-    }
-
-    fn draw_single_gender(&self, players: &[Player], gender: Gender) -> Vec<Vec<Uuid>> {
-        let mut pool = Self::player_ids_of_gender(players, gender);
-        pool.shuffle(&mut thread_rng());
-
-        let players_per_team: usize = self.players_per_team.into();
-        Self::chunk_into_teams(&pool, players_per_team)
-    }
-
-    fn draw_mixed(&self, players: &[Player]) -> Vec<Vec<Uuid>> {
-        let players_per_team: usize = self.players_per_team.into();
-        let players_per_gender = players_per_team / 2;
-
-        let mut males = Self::player_ids_of_gender(players, Gender::Male);
-        let mut females = Self::player_ids_of_gender(players, Gender::Female);
-        males.shuffle(&mut thread_rng());
-        females.shuffle(&mut thread_rng());
-
-        let team_count = (males.len() / players_per_gender).min(females.len() / players_per_gender);
-
-        (0..team_count)
-            .map(|i| {
-                let start = i * players_per_gender;
-                let end = start + players_per_gender;
-
-                let mut team = males[start..end].to_vec();
-                team.extend_from_slice(&females[start..end]);
-                team
-            })
-            .collect()
-    }
-
-    fn player_ids_of_gender(players: &[Player], gender: Gender) -> Vec<Uuid> {
-        players
-            .iter()
-            .filter(|player| *player.gender() == gender)
-            .map(|player| *player.id())
-            .collect()
-    }
-
-    fn chunk_into_teams(pool: &[Uuid], players_per_team: usize) -> Vec<Vec<Uuid>> {
-        pool.chunks_exact(players_per_team)
-            .map(|chunk| chunk.to_vec())
-            .collect()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use http_error::HttpErrorKind;
 
     use super::*;
+
+    #[test]
+    fn test_new_team_starts_waiting_with_no_wins() {
+        let team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        assert!(team.is_waiting());
+        assert_eq!(*team.consecutive_wins(), 0);
+    }
+
+    #[test]
+    fn test_register_win_once_holds_the_court() {
+        let mut team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        team.register_win();
+
+        assert!(team.is_holding());
+        assert_eq!(*team.consecutive_wins(), 1);
+    }
+
+    #[test]
+    fn test_register_win_twice_in_a_row_disbands_the_team() {
+        let mut team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        team.register_win();
+        team.register_win();
+
+        assert!(team.is_disbanded());
+        assert_eq!(*team.consecutive_wins(), 2);
+    }
+
+    #[test]
+    fn test_disband_is_idempotent() {
+        let mut team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        team.disband();
+        team.disband();
+
+        assert!(team.is_disbanded());
+    }
+
+    #[test]
+    fn test_is_complete_checks_player_count_against_players_per_team() {
+        let team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4()]);
+
+        assert!(!team.is_complete(2));
+
+        let full_team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        assert!(full_team.is_complete(2));
+    }
+
+    #[test]
+    fn test_add_player_extends_the_team() {
+        let player_id = Uuid::new_v4();
+        let mut team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4()]);
+
+        team.add_player(player_id);
+
+        assert!(team.player_ids().contains(&player_id));
+        assert!(team.is_complete(2));
+    }
 
     #[test]
     fn test_validate_new_team_with_no_existing_teams() {
@@ -290,110 +326,5 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.kind, HttpErrorKind::Conflict);
-    }
-
-    fn player(gender: Gender) -> Player {
-        Player::new("Player".to_string(), gender)
-    }
-
-    #[test]
-    fn test_draw_male_mode_only_pairs_male_players() {
-        let players = vec![
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Female),
-            player(Gender::Female),
-        ];
-        let male_ids: HashSet<Uuid> = players
-            .iter()
-            .filter(|player| *player.gender() == Gender::Male)
-            .map(|player| *player.id())
-            .collect();
-
-        let teams = TeamDrawer::new(GameMode::Male, 2).draw(&players).unwrap();
-
-        assert_eq!(teams.len(), 2);
-        for team in teams {
-            assert_eq!(team.len(), 2);
-            assert!(team.iter().all(|id| male_ids.contains(id)));
-        }
-    }
-
-    #[test]
-    fn test_draw_female_mode_leaves_leftover_player_unassigned() {
-        let players = vec![
-            player(Gender::Female),
-            player(Gender::Female),
-            player(Gender::Female),
-            player(Gender::Male),
-        ];
-
-        let teams = TeamDrawer::new(GameMode::Female, 2).draw(&players).unwrap();
-
-        assert_eq!(teams.len(), 1);
-        assert_eq!(teams[0].len(), 2);
-    }
-
-    #[test]
-    fn test_draw_mixed_mode_pairs_one_man_and_one_woman_per_team() {
-        let players = vec![
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Female),
-            player(Gender::Female),
-        ];
-        let male_ids: HashSet<Uuid> = players
-            .iter()
-            .filter(|player| *player.gender() == Gender::Male)
-            .map(|player| *player.id())
-            .collect();
-        let female_ids: HashSet<Uuid> = players
-            .iter()
-            .filter(|player| *player.gender() == Gender::Female)
-            .map(|player| *player.id())
-            .collect();
-
-        let teams = TeamDrawer::new(GameMode::Mixed, 2).draw(&players).unwrap();
-
-        assert_eq!(teams.len(), 2);
-        for team in teams {
-            assert_eq!(team.len(), 2);
-            assert_eq!(team.iter().filter(|id| male_ids.contains(id)).count(), 1);
-            assert_eq!(team.iter().filter(|id| female_ids.contains(id)).count(), 1);
-        }
-    }
-
-    #[test]
-    fn test_draw_mixed_mode_limited_by_smaller_gender_pool() {
-        let players = vec![
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Male),
-            player(Gender::Female),
-        ];
-
-        let teams = TeamDrawer::new(GameMode::Mixed, 2).draw(&players).unwrap();
-
-        assert_eq!(teams.len(), 1);
-    }
-
-    #[test]
-    fn test_draw_rejects_zero_players_per_team() {
-        let err = TeamDrawer::new(GameMode::Male, 0).draw(&[]).unwrap_err();
-
-        assert_eq!(err.kind, HttpErrorKind::BadRequest);
-    }
-
-    #[test]
-    fn test_draw_mixed_rejects_odd_players_per_team() {
-        let players = vec![player(Gender::Male), player(Gender::Female)];
-
-        let err = TeamDrawer::new(GameMode::Mixed, 3)
-            .draw(&players)
-            .unwrap_err();
-
-        assert_eq!(err.kind, HttpErrorKind::BadRequest);
     }
 }

--- a/api/src/modules/matchmaking/domain/team_drawer.rs
+++ b/api/src/modules/matchmaking/domain/team_drawer.rs
@@ -1,0 +1,391 @@
+use std::collections::HashSet;
+
+use http_error::{HttpError, HttpResult};
+use rand::{seq::SliceRandom, thread_rng};
+use uuid::Uuid;
+
+use crate::modules::matchmaking::domain::{
+    matches::Match,
+    player::{Gender, Player},
+    session::GameMode,
+    team::Team,
+};
+
+/// Tracks which players have already been teammates in a session, derived
+/// only from teams that actually took a court — a team that was drawn into
+/// the queue but got reshuffled away before playing doesn't count against
+/// future pairing.
+pub struct PartnerHistory {
+    played_pairs: HashSet<(Uuid, Uuid)>,
+}
+
+impl PartnerHistory {
+    pub fn empty() -> Self {
+        Self {
+            played_pairs: HashSet::new(),
+        }
+    }
+
+    pub fn from_matches(teams: &[Team], matches: &[Match]) -> Self {
+        let played_team_ids: HashSet<Uuid> = matches
+            .iter()
+            .flat_map(|match_| [*match_.team_a_id(), *match_.team_b_id()])
+            .collect();
+
+        let mut played_pairs = HashSet::new();
+        for team in teams
+            .iter()
+            .filter(|team| played_team_ids.contains(team.id()))
+        {
+            let player_ids = team.player_ids();
+            for i in 0..player_ids.len() {
+                for j in (i + 1)..player_ids.len() {
+                    played_pairs.insert(Self::normalize(player_ids[i], player_ids[j]));
+                }
+            }
+        }
+
+        Self { played_pairs }
+    }
+
+    pub fn have_played_together(&self, a: Uuid, b: Uuid) -> bool {
+        self.played_pairs.contains(&Self::normalize(a, b))
+    }
+
+    fn normalize(a: Uuid, b: Uuid) -> (Uuid, Uuid) {
+        if a < b {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+}
+
+/// Forms teams out of a pool of players, honoring the session's `GameMode`
+/// filter and, best-effort, avoiding pairing up players who are already
+/// teammate history according to a `PartnerHistory` (an empty history, e.g.
+/// a session's first draw, simply never blocks a pairing). Players left over
+/// (not enough to fill one more team) are never dropped — the last group
+/// formed may be an incomplete team, so the caller can still see who's
+/// waiting on a partner.
+pub struct TeamDrawer {
+    game_mode: GameMode,
+    players_per_team: u8,
+}
+
+impl TeamDrawer {
+    pub fn new(game_mode: GameMode, players_per_team: u8) -> Self {
+        Self {
+            game_mode,
+            players_per_team,
+        }
+    }
+
+    pub fn draw(&self, players: &[Player], history: &PartnerHistory) -> HttpResult<Vec<Vec<Uuid>>> {
+        if self.players_per_team == 0 {
+            return Err(Box::new(HttpError::bad_request(
+                "Session settings must have at least one player per team",
+            )));
+        }
+        self.game_mode
+            .validate_players_per_team(self.players_per_team)?;
+
+        match self.game_mode {
+            GameMode::Male => Ok(Self::draw_pool_greedy(
+                Self::player_ids_of_gender(players, Gender::Male),
+                self.players_per_team.into(),
+                history,
+            )),
+            GameMode::Female => Ok(Self::draw_pool_greedy(
+                Self::player_ids_of_gender(players, Gender::Female),
+                self.players_per_team.into(),
+                history,
+            )),
+            GameMode::Mixed => Ok(self.draw_mixed(players, history)),
+        }
+    }
+
+    fn draw_mixed(&self, players: &[Player], history: &PartnerHistory) -> Vec<Vec<Uuid>> {
+        let players_per_gender: usize = (self.players_per_team / 2).into();
+
+        let male_groups = Self::draw_pool_greedy(
+            Self::player_ids_of_gender(players, Gender::Male),
+            players_per_gender,
+            history,
+        );
+        let mut female_groups = Self::draw_pool_greedy(
+            Self::player_ids_of_gender(players, Gender::Female),
+            players_per_gender,
+            history,
+        );
+
+        let mut teams = Vec::with_capacity(male_groups.len());
+
+        for male_group in male_groups {
+            let Some(best_match_index) = (0..female_groups.len())
+                .min_by_key(|&i| Self::cross_conflicts(&male_group, &female_groups[i], history))
+            else {
+                teams.push(male_group);
+                continue;
+            };
+
+            let mut team = male_group;
+            team.extend(female_groups.remove(best_match_index));
+            teams.push(team);
+        }
+
+        teams.extend(female_groups);
+
+        teams
+    }
+
+    fn cross_conflicts(a: &[Uuid], b: &[Uuid], history: &PartnerHistory) -> usize {
+        a.iter()
+            .flat_map(|x| b.iter().map(move |y| (*x, *y)))
+            .filter(|(x, y)| history.have_played_together(*x, *y))
+            .count()
+    }
+
+    /// Most-constrained-first greedy pairing: shuffles the pool for baseline
+    /// randomness, then repeatedly anchors on whichever remaining player has
+    /// the most history conflicts and fills their team with the
+    /// lowest-conflict candidates available. Falls back to repeating a
+    /// pairing when no conflict-free candidate is left — best-effort, not a
+    /// global optimum.
+    fn draw_pool_greedy(
+        mut pool: Vec<Uuid>,
+        team_size: usize,
+        history: &PartnerHistory,
+    ) -> Vec<Vec<Uuid>> {
+        if team_size == 0 {
+            return Vec::new();
+        }
+
+        pool.shuffle(&mut thread_rng());
+        let mut teams = Vec::new();
+
+        while !pool.is_empty() {
+            if pool.len() <= team_size {
+                teams.push(std::mem::take(&mut pool));
+                break;
+            }
+
+            let anchor_index = (0..pool.len())
+                .max_by_key(|&i| {
+                    (0..pool.len())
+                        .filter(|&j| j != i && history.have_played_together(pool[i], pool[j]))
+                        .count()
+                })
+                .expect("pool is non-empty");
+            let mut team = vec![pool.remove(anchor_index)];
+
+            while team.len() < team_size {
+                let candidate_index = (0..pool.len())
+                    .min_by_key(|&i| {
+                        team.iter()
+                            .filter(|member| history.have_played_together(**member, pool[i]))
+                            .count()
+                    })
+                    .expect("pool is non-empty");
+                team.push(pool.remove(candidate_index));
+            }
+
+            teams.push(team);
+        }
+
+        teams
+    }
+
+    fn player_ids_of_gender(players: &[Player], gender: Gender) -> Vec<Uuid> {
+        players
+            .iter()
+            .filter(|player| *player.gender() == gender)
+            .map(|player| *player.id())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_error::HttpErrorKind;
+
+    use super::*;
+
+    fn player(gender: Gender) -> Player {
+        Player::new("Player".to_string(), gender)
+    }
+
+    #[test]
+    fn test_draw_male_mode_only_pairs_male_players() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+            player(Gender::Female),
+        ];
+        let male_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Male)
+            .map(|player| *player.id())
+            .collect();
+
+        let teams = TeamDrawer::new(GameMode::Male, 2)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 2);
+            assert!(team.iter().all(|id| male_ids.contains(id)));
+        }
+    }
+
+    #[test]
+    fn test_draw_female_mode_forms_an_incomplete_team_with_the_leftover_player() {
+        let players = vec![
+            player(Gender::Female),
+            player(Gender::Female),
+            player(Gender::Female),
+            player(Gender::Male),
+        ];
+
+        let teams = TeamDrawer::new(GameMode::Female, 2)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        assert_eq!(teams.len(), 2);
+        let sizes: Vec<usize> = teams.iter().map(Vec::len).collect();
+        assert!(sizes.contains(&2));
+        assert!(sizes.contains(&1));
+    }
+
+    #[test]
+    fn test_draw_mixed_mode_pairs_one_man_and_one_woman_per_team() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+            player(Gender::Female),
+        ];
+        let male_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Male)
+            .map(|player| *player.id())
+            .collect();
+        let female_ids: HashSet<Uuid> = players
+            .iter()
+            .filter(|player| *player.gender() == Gender::Female)
+            .map(|player| *player.id())
+            .collect();
+
+        let teams = TeamDrawer::new(GameMode::Mixed, 2)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 2);
+            assert_eq!(team.iter().filter(|id| male_ids.contains(id)).count(), 1);
+            assert_eq!(team.iter().filter(|id| female_ids.contains(id)).count(), 1);
+        }
+    }
+
+    #[test]
+    fn test_draw_mixed_mode_limited_by_smaller_gender_pool_leaves_incomplete_teams() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+        ];
+
+        let teams = TeamDrawer::new(GameMode::Mixed, 2)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        let total_players: usize = teams.iter().map(Vec::len).sum();
+        assert_eq!(total_players, 4);
+        assert!(teams.iter().any(|team| team.len() == 2));
+        assert!(teams.iter().any(|team| team.len() == 1));
+    }
+
+    #[test]
+    fn test_draw_rejects_zero_players_per_team() {
+        let err = TeamDrawer::new(GameMode::Male, 0)
+            .draw(&[], &PartnerHistory::empty())
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_draw_mixed_rejects_odd_players_per_team() {
+        let players = vec![player(Gender::Male), player(Gender::Female)];
+
+        let err = TeamDrawer::new(GameMode::Mixed, 3)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_draw_avoids_repeating_a_pair_when_an_alternative_exists() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Male),
+        ];
+        let ids: Vec<Uuid> = players.iter().map(|p| *p.id()).collect();
+
+        let mut played_pairs = HashSet::new();
+        played_pairs.insert(PartnerHistory::normalize(ids[0], ids[1]));
+        let history = PartnerHistory { played_pairs };
+
+        let teams = TeamDrawer::new(GameMode::Male, 2)
+            .draw(&players, &history)
+            .unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert!(!history.have_played_together(team[0], team[1]));
+        }
+    }
+
+    #[test]
+    fn test_draw_accepts_repeating_a_pair_when_forced() {
+        let players = vec![player(Gender::Male), player(Gender::Male)];
+        let ids: Vec<Uuid> = players.iter().map(|p| *p.id()).collect();
+
+        let mut played_pairs = HashSet::new();
+        played_pairs.insert(PartnerHistory::normalize(ids[0], ids[1]));
+        let history = PartnerHistory { played_pairs };
+
+        let teams = TeamDrawer::new(GameMode::Male, 2)
+            .draw(&players, &history)
+            .unwrap();
+
+        assert_eq!(teams.len(), 1);
+        assert_eq!(
+            teams[0].iter().collect::<HashSet<_>>(),
+            ids.iter().collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_draw_generalizes_to_teams_larger_than_two() {
+        let players: Vec<Player> = (0..8).map(|_| player(Gender::Male)).collect();
+
+        let teams = TeamDrawer::new(GameMode::Male, 4)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 4);
+        }
+    }
+}

--- a/api/src/modules/matchmaking/domain/team_queue.rs
+++ b/api/src/modules/matchmaking/domain/team_queue.rs
@@ -1,0 +1,264 @@
+use rand::{seq::SliceRandom, thread_rng};
+use uuid::Uuid;
+
+use crate::modules::matchmaking::domain::{
+    player::{Gender, Player},
+    session::GameMode,
+    team::Team,
+    team_drawer::PartnerHistory,
+};
+
+/// Keeps the session's waiting queue moving: when players are freed (a team
+/// lost, or a team hit the consecutive-win cap), slots them into the queue —
+/// completing an incomplete team waiting for a partner if one is compatible,
+/// or starting a new incomplete team otherwise — and answers "who's next" so
+/// a freed-up court can be refilled automatically. Bound to a `session_id`,
+/// `game_mode` and `players_per_team`, the same values a `TeamDrawer` for
+/// this session would use, since the queue has to honor the same shape of
+/// team the initial draw formed.
+pub struct TeamQueueManager {
+    session_id: Uuid,
+    game_mode: GameMode,
+    players_per_team: u8,
+}
+
+impl TeamQueueManager {
+    pub fn new(session_id: Uuid, game_mode: GameMode, players_per_team: u8) -> Self {
+        Self {
+            session_id,
+            game_mode,
+            players_per_team,
+        }
+    }
+
+    /// Slots freed players into the waiting queue, in random order (no rule
+    /// about which of several freed players completes an incomplete team
+    /// versus starts a new one). Returns every team that was created or
+    /// modified, for the caller to persist — teams left untouched are not
+    /// included.
+    pub fn release_players(
+        &self,
+        waiting_teams: &[Team],
+        freed_player_ids: &[Uuid],
+        players: &[Player],
+        history: &PartnerHistory,
+    ) -> Vec<Team> {
+        let mut order = freed_player_ids.to_vec();
+        order.shuffle(&mut thread_rng());
+
+        let mut pending: Vec<Team> = waiting_teams
+            .iter()
+            .filter(|team| team.is_waiting() && !team.is_complete(self.players_per_team))
+            .cloned()
+            .collect();
+        let mut touched_ids = std::collections::HashSet::new();
+
+        for player_id in order {
+            let gender = Self::gender_of(players, player_id);
+
+            let candidate_index = (0..pending.len())
+                .filter(|&index| {
+                    !pending[index].is_complete(self.players_per_team)
+                        && self.needs_gender(&pending[index], gender, players)
+                })
+                .min_by_key(|&index| {
+                    pending[index]
+                        .player_ids()
+                        .iter()
+                        .filter(|member| history.have_played_together(**member, player_id))
+                        .count()
+                });
+
+            match candidate_index {
+                Some(index) => {
+                    pending[index].add_player(player_id);
+                    touched_ids.insert(*pending[index].id());
+                }
+                None => {
+                    let new_team = Team::new(self.session_id, vec![player_id]);
+                    touched_ids.insert(*new_team.id());
+                    pending.push(new_team);
+                }
+            }
+        }
+
+        pending
+            .into_iter()
+            .filter(|team| touched_ids.contains(team.id()))
+            .collect()
+    }
+
+    /// The next `count` complete teams in the queue, oldest first — the
+    /// ones that should auto-fill a court that just freed up.
+    pub fn next_complete_teams<'a>(
+        &self,
+        waiting_teams: &'a [Team],
+        count: usize,
+    ) -> Vec<&'a Team> {
+        let mut complete: Vec<&Team> = waiting_teams
+            .iter()
+            .filter(|team| team.is_waiting() && team.is_complete(self.players_per_team))
+            .collect();
+        complete.sort_by_key(|team| *team.created_at());
+
+        complete.into_iter().take(count).collect()
+    }
+
+    /// Whether `team` still needs another player of `gender` to be complete.
+    /// Any incomplete team is compatible in a single-gender mode; in `Mixed`
+    /// mode, a team only accepts a gender it hasn't already filled its half
+    /// of `players_per_team` with.
+    fn needs_gender(&self, team: &Team, gender: Gender, players: &[Player]) -> bool {
+        if !self.game_mode.is_mixed() {
+            return true;
+        }
+
+        let target_per_gender: usize = (self.players_per_team / 2).into();
+        let current = team
+            .player_ids()
+            .iter()
+            .filter(|player_id| Self::gender_of(players, **player_id) == gender)
+            .count();
+
+        current < target_per_gender
+    }
+
+    fn gender_of(players: &[Player], player_id: Uuid) -> Gender {
+        players
+            .iter()
+            .find(|player| *player.id() == player_id)
+            .map(|player| *player.gender())
+            .expect("freed player must be part of the session roster")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn player(gender: Gender) -> Player {
+        Player::new("Player".to_string(), gender)
+    }
+
+    #[test]
+    fn test_release_players_completes_the_waiting_incomplete_team_and_starts_a_new_one() {
+        let session_id = Uuid::new_v4();
+        let waiting_alone = Player::new("15".to_string(), Gender::Male);
+        let freed_a = Player::new("1".to_string(), Gender::Male);
+        let freed_b = Player::new("2".to_string(), Gender::Male);
+        let players = vec![waiting_alone.clone(), freed_a.clone(), freed_b.clone()];
+
+        let incomplete_team = Team::new(session_id, vec![*waiting_alone.id()]);
+        let manager = TeamQueueManager::new(session_id, GameMode::Male, 2);
+
+        let changed = manager.release_players(
+            &[incomplete_team.clone()],
+            &[*freed_a.id(), *freed_b.id()],
+            &players,
+            &PartnerHistory::empty(),
+        );
+
+        assert_eq!(changed.len(), 2);
+        let completed = changed
+            .iter()
+            .find(|team| *team.id() == *incomplete_team.id())
+            .expect("the original incomplete team should have been completed");
+        assert!(completed.is_complete(2));
+        assert!(completed.player_ids().contains(waiting_alone.id()));
+
+        let new_incomplete = changed
+            .iter()
+            .find(|team| *team.id() != *incomplete_team.id())
+            .expect("the other freed player should start a new incomplete team");
+        assert_eq!(new_incomplete.player_ids().len(), 1);
+    }
+
+    #[test]
+    fn test_release_players_forms_a_new_complete_team_when_no_incomplete_team_is_waiting() {
+        let session_id = Uuid::new_v4();
+        let freed_a = player(Gender::Female);
+        let freed_b = player(Gender::Female);
+        let players = vec![freed_a.clone(), freed_b.clone()];
+
+        let manager = TeamQueueManager::new(session_id, GameMode::Female, 2);
+
+        let changed = manager.release_players(
+            &[],
+            &[*freed_a.id(), *freed_b.id()],
+            &players,
+            &PartnerHistory::empty(),
+        );
+
+        assert_eq!(changed.len(), 1);
+        assert!(changed[0].is_complete(2));
+    }
+
+    #[test]
+    fn test_release_players_in_mixed_mode_only_completes_a_team_needing_that_gender() {
+        let session_id = Uuid::new_v4();
+        let waiting_male = player(Gender::Male);
+        let freed_male = player(Gender::Male);
+        let freed_female = player(Gender::Female);
+        let players = vec![
+            waiting_male.clone(),
+            freed_male.clone(),
+            freed_female.clone(),
+        ];
+
+        let incomplete_team = Team::new(session_id, vec![*waiting_male.id()]);
+        let manager = TeamQueueManager::new(session_id, GameMode::Mixed, 2);
+
+        let changed = manager.release_players(
+            &[incomplete_team.clone()],
+            &[*freed_male.id(), *freed_female.id()],
+            &players,
+            &PartnerHistory::empty(),
+        );
+
+        let completed = changed
+            .iter()
+            .find(|team| *team.id() == *incomplete_team.id())
+            .expect("the waiting male should only be completed by the freed female");
+        assert!(completed.player_ids().contains(freed_female.id()));
+        assert!(!completed.player_ids().contains(freed_male.id()));
+
+        let new_incomplete = changed
+            .iter()
+            .find(|team| *team.id() != *incomplete_team.id())
+            .expect("the freed male starts its own incomplete team");
+        assert_eq!(new_incomplete.player_ids(), &vec![*freed_male.id()]);
+    }
+
+    #[test]
+    fn test_next_complete_teams_skips_incomplete_and_orders_by_creation() {
+        let session_id = Uuid::new_v4();
+        let manager = TeamQueueManager::new(session_id, GameMode::Male, 2);
+
+        let incomplete = Team::new(session_id, vec![Uuid::new_v4()]);
+        let first_complete = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let second_complete = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+
+        let waiting_teams = vec![incomplete, second_complete.clone(), first_complete.clone()];
+
+        let next = manager.next_complete_teams(&waiting_teams, 2);
+
+        assert_eq!(next.len(), 2);
+        assert_eq!(*next[0].id(), *first_complete.id());
+        assert_eq!(*next[1].id(), *second_complete.id());
+    }
+
+    #[test]
+    fn test_next_complete_teams_ignores_non_waiting_teams() {
+        let session_id = Uuid::new_v4();
+        let manager = TeamQueueManager::new(session_id, GameMode::Male, 2);
+
+        let mut holding = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+        holding.register_win();
+
+        let waiting_teams = [holding];
+        let next = manager.next_complete_teams(&waiting_teams, 1);
+
+        assert!(next.is_empty());
+    }
+}

--- a/api/src/modules/matchmaking/handler/matches.rs
+++ b/api/src/modules/matchmaking/handler/matches.rs
@@ -5,20 +5,29 @@ use http_error::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::{
-    domain::matches::Match,
-    handler::matches::use_cases::{CreateMatchRequest, ReportMatchResultRequest},
-    repository::matches::DynMatchRepository,
+    domain::matches::{Match, MatchStartValidator},
+    handler::{
+        matches::use_cases::{CreateMatchRequest, ReportMatchResultRequest},
+        team::DynTeamHandler,
+    },
+    repository::{matches::DynMatchRepository, session::DynSessionRepository},
 };
 
 #[async_trait]
 pub trait MatchHandler {
     /// Starts a match on a court: assigns the two teams facing off, with no
-    /// result yet.
+    /// result yet. Used to open a court for the first time — once it's
+    /// occupied, further matches on it are created automatically as results
+    /// come in (see `report_match_result`).
     async fn create_match(&self, request: CreateMatchRequest) -> HttpResult<Match>;
 
     async fn list_matches_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Match>>;
 
-    /// Reports the result of a match that's in progress on a court.
+    /// Reports the result of a match that's in progress on a court, and
+    /// applies the resulting rotation: the loser is always disbanded, the
+    /// winner keeps (or loses) the court per the consecutive-win cap, and if
+    /// the queue already has the team(s) needed to keep that court going,
+    /// the next match there is started automatically.
     async fn report_match_result(
         &self,
         match_id: Uuid,
@@ -31,11 +40,35 @@ pub type DynMatchHandler = dyn MatchHandler + Send + Sync;
 #[derive(Clone)]
 pub struct MatchHandlerImpl {
     pub match_repository: Arc<DynMatchRepository>,
+    pub session_repository: Arc<DynSessionRepository>,
+    pub team_handler: Arc<DynTeamHandler>,
 }
 
 #[async_trait]
 impl MatchHandler for MatchHandlerImpl {
     async fn create_match(&self, request: CreateMatchRequest) -> HttpResult<Match> {
+        let session = self
+            .session_repository
+            .get(&request.session_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Session", request.session_id)))?;
+        let session_teams = self
+            .team_handler
+            .list_teams_by_session(request.session_id)
+            .await?;
+        let session_matches = self
+            .match_repository
+            .list_by_session(&request.session_id)
+            .await?;
+
+        MatchStartValidator::new(request.session_id, *session.settings().players_per_team())
+            .validate_start(
+                &session_teams,
+                &session_matches,
+                request.team_a_id,
+                request.team_b_id,
+            )?;
+
         let match_ = Match::new(
             request.session_id,
             request.court,
@@ -62,8 +95,46 @@ impl MatchHandler for MatchHandlerImpl {
             .ok_or_else(|| Box::new(HttpError::not_found("Match", match_id)))?;
 
         match_.finish(request.winner_team_id)?;
+        let finished_match = self.match_repository.update(match_).await?;
 
-        self.match_repository.update(match_).await
+        let loser_team_id = if request.winner_team_id == *finished_match.team_a_id() {
+            *finished_match.team_b_id()
+        } else {
+            *finished_match.team_a_id()
+        };
+
+        let rotation = self
+            .team_handler
+            .resolve_match_result(
+                *finished_match.session_id(),
+                request.winner_team_id,
+                loser_team_id,
+            )
+            .await?;
+
+        // The teams in `rotation.next_teams` were just computed straight off
+        // the queue (complete, waiting, not busy elsewhere), so there's
+        // nothing left for `MatchStartValidator` to catch here.
+        let next_match = match (
+            rotation.winner_still_holding,
+            rotation.next_teams.as_slice(),
+        ) {
+            (true, [challenger]) => Some((rotation.winner_team_id, *challenger.id())),
+            (false, [team_a, team_b]) => Some((*team_a.id(), *team_b.id())),
+            _ => None,
+        };
+
+        if let Some((team_a_id, team_b_id)) = next_match {
+            let next = Match::new(
+                *finished_match.session_id(),
+                *finished_match.court(),
+                team_a_id,
+                team_b_id,
+            )?;
+            self.match_repository.insert(next).await?;
+        }
+
+        Ok(finished_match)
     }
 }
 

--- a/api/src/modules/matchmaking/handler/team.rs
+++ b/api/src/modules/matchmaking/handler/team.rs
@@ -5,10 +5,16 @@ use http_error::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::{
-    domain::team::{Team, TeamDrawer, TeamValidator},
-    handler::team::use_cases::CreateTeamRequest,
+    domain::{
+        matches::Match,
+        team::{Team, TeamValidator},
+        team_drawer::{PartnerHistory, TeamDrawer},
+        team_queue::TeamQueueManager,
+    },
+    handler::team::use_cases::{CreateTeamRequest, ResolvedRotation},
     repository::{
-        player::DynPlayerRepository, session::DynSessionRepository, team::DynTeamRepository,
+        matches::DynMatchRepository, player::DynPlayerRepository, session::DynSessionRepository,
+        team::DynTeamRepository,
     },
 };
 
@@ -22,6 +28,19 @@ pub trait TeamHandler {
     /// confirmed players, honoring the session's `GameMode` filter. Fails if
     /// the session already has teams, since it's meant to initialize them.
     async fn draw_teams(&self, session_id: Uuid) -> HttpResult<Vec<Team>>;
+
+    /// Applies a match's result to the team rotation: the loser is always
+    /// disbanded, the winner either keeps holding the court (up to the
+    /// consecutive-win cap) or is disbanded too, and every player freed by
+    /// either outcome is slotted back into the waiting queue. Returns
+    /// whichever complete team(s) should now auto-fill the freed court
+    /// slot(s), if the queue already has enough of them.
+    async fn resolve_match_result(
+        &self,
+        session_id: Uuid,
+        winner_team_id: Uuid,
+        loser_team_id: Uuid,
+    ) -> HttpResult<ResolvedRotation>;
 }
 
 pub type DynTeamHandler = dyn TeamHandler + Send + Sync;
@@ -31,6 +50,7 @@ pub struct TeamHandlerImpl {
     pub team_repository: Arc<DynTeamRepository>,
     pub session_repository: Arc<DynSessionRepository>,
     pub player_repository: Arc<DynPlayerRepository>,
+    pub match_repository: Arc<DynMatchRepository>,
 }
 
 #[async_trait]
@@ -77,7 +97,7 @@ impl TeamHandler for TeamHandlerImpl {
 
         let drawn_teams =
             TeamDrawer::new(*session.game_mode(), *session.settings().players_per_team())
-                .draw(&session_players)?;
+                .draw(&session_players, &PartnerHistory::empty())?;
 
         if drawn_teams.is_empty() {
             return Err(Box::new(HttpError::bad_request(
@@ -97,16 +117,137 @@ impl TeamHandler for TeamHandlerImpl {
 
         Ok(created_teams)
     }
+
+    async fn resolve_match_result(
+        &self,
+        session_id: Uuid,
+        winner_team_id: Uuid,
+        loser_team_id: Uuid,
+    ) -> HttpResult<ResolvedRotation> {
+        let session = self
+            .session_repository
+            .get(&session_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Session", session_id)))?;
+
+        let session_teams = self.team_repository.list_by_session(&session_id).await?;
+        let session_matches = self.match_repository.list_by_session(&session_id).await?;
+        let history = PartnerHistory::from_matches(&session_teams, &session_matches);
+        let busy_team_ids = Match::busy_team_ids(&session_matches);
+
+        let mut winner = self
+            .team_repository
+            .get(&winner_team_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Team", winner_team_id)))?;
+        let mut loser = self
+            .team_repository
+            .get(&loser_team_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Team", loser_team_id)))?;
+
+        loser.disband();
+        winner.register_win();
+        let winner_still_holding = winner.is_holding();
+
+        let mut freed_player_ids = loser.player_ids().clone();
+        if !winner_still_holding {
+            freed_player_ids.extend(winner.player_ids().clone());
+        }
+
+        self.team_repository.insert(loser).await?;
+        self.team_repository.insert(winner).await?;
+
+        let session_players: Vec<_> = self
+            .player_repository
+            .list()
+            .await?
+            .into_iter()
+            .filter(|player| session.player_ids().contains(player.id()))
+            .collect();
+
+        let queue_manager = TeamQueueManager::new(
+            session_id,
+            *session.game_mode(),
+            *session.settings().players_per_team(),
+        );
+
+        // The winner/loser rows above are stale here (fetched before this
+        // resolution mutated them), and a `Waiting` team elsewhere in the
+        // session might actually be busy on another court right now — both
+        // must be kept out of the queue view this rotation acts on.
+        let mut waiting_teams: Vec<Team> = session_teams
+            .into_iter()
+            .filter(|team| {
+                team.is_waiting()
+                    && *team.id() != winner_team_id
+                    && *team.id() != loser_team_id
+                    && !busy_team_ids.contains(team.id())
+            })
+            .collect();
+
+        let changed_teams = queue_manager.release_players(
+            &waiting_teams,
+            &freed_player_ids,
+            &session_players,
+            &history,
+        );
+
+        for team in &changed_teams {
+            self.team_repository.insert(team.clone()).await?;
+        }
+
+        for changed in changed_teams {
+            match waiting_teams
+                .iter_mut()
+                .find(|team| team.id() == changed.id())
+            {
+                Some(existing) => *existing = changed,
+                None => waiting_teams.push(changed),
+            }
+        }
+
+        let needed_teams = if winner_still_holding { 1 } else { 2 };
+        let next_teams: Vec<Team> = queue_manager
+            .next_complete_teams(&waiting_teams, needed_teams)
+            .into_iter()
+            .cloned()
+            .collect();
+
+        Ok(ResolvedRotation {
+            winner_team_id,
+            winner_still_holding,
+            next_teams: if next_teams.len() == needed_teams {
+                next_teams
+            } else {
+                Vec::new()
+            },
+        })
+    }
 }
 
 pub mod use_cases {
     use serde::{Deserialize, Serialize};
     use uuid::Uuid;
 
+    use crate::modules::matchmaking::domain::team::Team;
+
     #[derive(Debug, Clone, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CreateTeamRequest {
         pub session_id: Uuid,
         pub player_ids: Vec<Uuid>,
+    }
+
+    /// The outcome of applying a match result to the team rotation: whether
+    /// the winner is still holding its court, and whichever complete
+    /// team(s) from the queue should now auto-fill the freed slot(s) —
+    /// empty when the winner rotated out but the queue doesn't have two
+    /// complete teams ready yet.
+    #[derive(Debug, Clone)]
+    pub struct ResolvedRotation {
+        pub winner_team_id: Uuid,
+        pub winner_still_holding: bool,
+        pub next_teams: Vec<Team>,
     }
 }

--- a/api/src/modules/matchmaking/repository/team.rs
+++ b/api/src/modules/matchmaking/repository/team.rs
@@ -11,6 +11,8 @@ pub trait TeamRepository {
     async fn insert(&self, team: Team) -> HttpResult<Team>;
 
     async fn list_by_session(&self, session_id: &Uuid) -> HttpResult<Vec<Team>>;
+
+    async fn get(&self, id: &Uuid) -> HttpResult<Option<Team>>;
 }
 
 pub type DynTeamRepository = dyn TeamRepository + Send + Sync;
@@ -45,5 +47,11 @@ impl TeamRepository for InMemoryTeamRepository {
             .filter(|team| team.session_id() == session_id)
             .cloned()
             .collect())
+    }
+
+    async fn get(&self, id: &Uuid) -> HttpResult<Option<Team>> {
+        let teams = self.teams.lock().expect("team repository lock poisoned");
+
+        Ok(teams.get(id).cloned())
     }
 }


### PR DESCRIPTION
Team gains a status (Waiting/Holding/Disbanded) and a consecutive-win counter: a losing team is always disbanded, a winning team holds its court for one more match and rotates out after 2 consecutive wins. Freed players are slotted into a FIFO waiting queue (TeamQueueManager) that never drops leftover players (forms an incomplete team instead) and, best-effort, avoids re-pairing partners who already played together (PartnerHistory).

report_match_result now resolves this rotation automatically and starts the court's next match by itself, so create_match is only needed to open a court for the first time. create_match also gains MatchStartValidator, closing previously-known gaps: teams must belong to the session, be complete, not be disbanded, and not already be busy in another in-progress match.