### PR TITLE
feat(matchmaking): add gender-independent RoundRobin shuffle type

### DIFF
--- a/.claude/skills/gb-matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/gb-matchmaking-business-rules/SKILL.md
@@ -13,11 +13,14 @@ description: Regras de negócio do módulo de matchmaking — critérios de pare
 
 ## Critérios de pareamento
 
-- Toda `Session` tem um `GameMode` (`Male`, `Female` ou `Mixed`), que filtra
-  quem pode formar dupla junto: `Male`/`Female` só pareiam jogadores do
-  mesmo gênero; `Mixed` forma cada `Team` com metade dos jogadores homens e
-  metade mulheres (com `players_per_team = 2`, na prática 1 homem + 1
-  mulher).
+- Toda `Session` tem um `GameMode` (`Male`, `Female`, `Mixed` ou `Open`), que
+  filtra quem pode formar dupla junto: `Male`/`Female` só pareiam jogadores
+  do mesmo gênero; `Mixed` forma cada `Team` com metade dos jogadores homens
+  e metade mulheres (com `players_per_team = 2`, na prática 1 homem + 1
+  mulher); `Open` ignora gênero totalmente — qualquer jogador pode formar
+  dupla com qualquer outro. `Open` só é válido combinado com
+  `ShuffleType::RoundRobin` (ver seção seguinte); qualquer outra combinação
+  é rejeitada por `GameMode::validate_shuffle_type`.
 - O sorteio (tanto o inicial quanto os que acontecem conforme partidas
   terminam) evita, best-effort, formar uma `Team` com dois jogadores que já
   jogaram juntos como parceiros na mesma `Session` — mas aceita repetir se
@@ -44,11 +47,19 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
 ### Fila e rotação de quadra
 
 - Toda `Session` tem um `ShuffleType`, que escolhe a estratégia de rotação
-  usada conforme as partidas terminam. Hoje só existe a estratégia
-  `KingAndQueen` (a fila contínua com rotação por vitórias descrita abaixo),
-  mas o campo já é explícito e obrigatório na `Session` (mesmo padrão do
-  `GameMode`) para permitir uma estratégia diferente no futuro sem que
-  nenhuma `Session` mude de comportamento silenciosamente.
+  usada conforme as partidas terminam: `KingAndQueen` (fila contínua com
+  rotação por vitórias, descrita abaixo) ou `RoundRobin` (só válido com
+  `GameMode::Open` — mesma mecânica de vitória/derrota do `KingAndQueen`,
+  mas a fila prioriza fortemente formar duplas inéditas: um jogador liberado
+  só completa um time incompleto da fila se essa dupla nunca jogou junta na
+  `Session`; se todos os times incompletos esperando já jogaram com ele,
+  abre um time novo em vez de repetir a dupla — nunca força a repetição
+  enquanto existir alternativa. O sorteio *inicial* nesse modo continua
+  puramente aleatório, sem gênero, igual aos outros modos — a garantia de
+  "duplas inéditas" só entra em ação na fila, conforme as partidas
+  terminam). O campo é explícito e obrigatório na `Session` (mesmo padrão do
+  `GameMode`) para que nenhuma `Session` mude de comportamento
+  silenciosamente.
 - Uma `Team` tem um `status`: `Waiting` (na fila, disponível pra entrar em
   quadra), `Holding` (venceu e está segurando a quadra aguardando o próximo
   desafiante) ou `Disbanded` (perdeu, ou girou pra fora por ter batido o
@@ -66,7 +77,12 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
   completar uma `Team` incompleta compatível (mesmo gênero necessário, no
   caso `Mixed`) já esperando na fila; se não achar, inicia uma nova `Team`
   incompleta. Sem regra especial de "qual dos jogadores liberados" completa
-  a sobra existente. Implementado por `TeamQueueManager::release_players`
+  a sobra existente. Em `RoundRobin` (`GameMode::Open`), a compatibilidade
+  também exige zero conflito de histórico com o jogador liberado
+  (`GameMode::requires_fresh_partner`) — só entra num time incompleto que
+  ainda não jogou com ele; caso contrário abre time novo, mesmo que isso
+  signifique acumular mais de uma `Team` incompleta em paralelo. Implementado
+  por `TeamQueueManager::release_players`
   (`api/src/modules/matchmaking/domain/team_queue.rs`).
 - **Continuação automática da quadra:** ao reportar o resultado de um
   `Match` (`POST /matchmaking/matches/{match_id}/result`), o sistema já
@@ -93,6 +109,13 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
   `Session::new`/`set_settings`/`set_game_mode`) quanto no sorteio
   (`TeamDrawer::draw`), para que uma `Session` nunca fique salva numa
   configuração que o sorteio não consegue honrar.
+- `GameMode::Open` só pode ser combinado com `ShuffleType::RoundRobin`, e
+  vice-versa — qualquer outra combinação retorna `HttpError::bad_request`
+  (`GameMode::validate_shuffle_type`). Validado em `Session::new`,
+  `set_game_mode`, `set_shuffle_type` e `set_game_mode_and_shuffle_type`
+  (esse último usado quando os dois campos mudam na mesma atualização, pra
+  validar o par final em vez de passar por um estado intermediário
+  inválido — ver `SessionHandlerImpl::update_session`).
 - `draw_teams` só pode ser chamado uma vez por `Session` (é o sorteio de
   *inicialização*): se a `Session` já tiver alguma `Team`, retorna
   `HttpError::conflict`. Não existe hoje endpoint para resetar/re-sortear
@@ -153,6 +176,15 @@ Ex: balanceamento de nível tem prioridade sobre variar parceiros.
   (`TeamQueueManager::needs_gender`) — se o desbalanceamento de gênero for
   grande, podem se acumular várias `Team`s incompletas em paralelo (uma por
   gênero em falta), não só uma. Comportamento aceito, não é bug.
+- Em `RoundRobin`, pelo mesmo motivo (recusa ativamente completar um time
+  que repetiria uma dupla), grupos pequenos com histórico de parceria muito
+  concentrado podem acumular várias `Team`s incompletas simultâneas em vez
+  de uma só. A decisão de quem completa qual time é local por jogador
+  liberado (não um rebalanceamento global da fila), então não há garantia
+  de que o resultado seja o arranjo com o mínimo global de duplas repetidas
+  possível — só que nenhum jogador é forçado a repetir parceiro enquanto
+  ele, individualmente, tiver uma alternativa disponível no momento em que
+  é liberado. Comportamento aceito, não é bug.
 
 <!--
 Situações especiais já discutidas/decididas. Ex: número ímpar de jogadores,
@@ -162,6 +194,15 @@ removido de uma Session após os times já terem sido sorteados, etc.
 
 ## Histórico de mudanças
 
+- 2026-08-14 — adicionado `GameMode::Open` (ignora gênero na formação de
+  times) e `ShuffleType::RoundRobin` (mesma mecânica de fila/quadra do
+  `KingAndQueen`, mas a fila prioriza fortemente duplas inéditas ao
+  completar times incompletos, abrindo time novo em vez de repetir parceiro
+  quando há alternativa). Os dois só são válidos combinados entre si
+  (`GameMode::validate_shuffle_type`). O sorteio inicial nesse modo continua
+  aleatório sem garantia especial (histórico sempre vazio nesse ponto); a
+  garantia de "duplas inéditas" vale só pra fila, conforme partidas
+  terminam (`TeamQueueManager::release_players`).
 - 2026-08-12 — adicionado `ShuffleType` (hoje só `KingAndQueen`) como campo
   obrigatório de `Session`. Formaliza como estratégia nomeada e selecionável
   a rotação de fila contínua por vitórias que já existia (2026-08-07),

--- a/api/src/modules/matchmaking/domain/session.rs
+++ b/api/src/modules/matchmaking/domain/session.rs
@@ -5,18 +5,32 @@ use util::getters;
 use uuid::Uuid;
 
 /// Filter applied when drawing teams for a `Session`: pairs restricted to
-/// men, restricted to women, or mixed (1 man + 1 woman per team).
+/// men, restricted to women, mixed (1 man + 1 woman per team), or open
+/// (gender not considered at all — only valid together with
+/// `ShuffleType::RoundRobin`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum GameMode {
     Male,
     Female,
     Mixed,
+    Open,
 }
 
 impl GameMode {
     pub fn is_mixed(&self) -> bool {
         *self == GameMode::Mixed
+    }
+
+    pub fn is_open(&self) -> bool {
+        *self == GameMode::Open
+    }
+
+    /// Whether the queue must never pair up two players who already played
+    /// together while a fresh pairing is available. Only `Open` demands
+    /// this — the other modes keep the best-effort pairing they've always had.
+    pub fn requires_fresh_partner(&self) -> bool {
+        self.is_open()
     }
 
     /// `Mixed` needs to split `players_per_team` evenly between men and
@@ -32,6 +46,26 @@ impl GameMode {
 
         Ok(())
     }
+
+    /// `Open` (gender not considered) only makes sense paired with
+    /// `ShuffleType::RoundRobin` (the strategy that leans on that freedom to
+    /// chase novel pairings), and `RoundRobin` only makes sense paired with
+    /// `Open` — checked here, at the Session boundary, so the two fields can
+    /// never drift into an inconsistent combination.
+    pub fn validate_shuffle_type(&self, shuffle_type: ShuffleType) -> HttpResult<()> {
+        let compatible = match self {
+            GameMode::Open => shuffle_type == ShuffleType::RoundRobin,
+            _ => shuffle_type != ShuffleType::RoundRobin,
+        };
+
+        if !compatible {
+            return Err(Box::new(HttpError::bad_request(
+                "GameMode::Open and ShuffleType::RoundRobin can only be used together",
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 /// The strategy governing how a session's team queue evolves as matches
@@ -40,6 +74,12 @@ impl GameMode {
 #[serde(rename_all = "camelCase")]
 pub enum ShuffleType {
     KingAndQueen,
+    /// Same win/loss court-holding mechanic as `KingAndQueen`, but the queue
+    /// only completes an incomplete team with a freed player when that
+    /// pairing is brand new — it opens a new team instead of repeating a
+    /// pairing while a fresh alternative exists. Only valid with
+    /// `GameMode::Open`.
+    RoundRobin,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -93,6 +133,7 @@ impl Session {
         shuffle_type: ShuffleType,
     ) -> HttpResult<Self> {
         game_mode.validate_players_per_team(*settings.players_per_team())?;
+        game_mode.validate_shuffle_type(shuffle_type)?;
 
         Ok(Self {
             id: Uuid::new_v4(),
@@ -128,15 +169,39 @@ impl Session {
 
     pub fn set_game_mode(&mut self, game_mode: GameMode) -> HttpResult<()> {
         game_mode.validate_players_per_team(*self.settings.players_per_team())?;
+        game_mode.validate_shuffle_type(self.shuffle_type)?;
         self.game_mode = game_mode;
         self.updated_at = Some(Utc::now());
 
         Ok(())
     }
 
-    pub fn set_shuffle_type(&mut self, shuffle_type: ShuffleType) {
+    pub fn set_shuffle_type(&mut self, shuffle_type: ShuffleType) -> HttpResult<()> {
+        self.game_mode.validate_shuffle_type(shuffle_type)?;
         self.shuffle_type = shuffle_type;
         self.updated_at = Some(Utc::now());
+
+        Ok(())
+    }
+
+    /// Sets `game_mode` and `shuffle_type` together, validating the pair as
+    /// the target state rather than validating each field against the
+    /// other's current value in sequence — needed because swapping between
+    /// two mutually exclusive combinations (e.g. `Male`+`KingAndQueen` to
+    /// `Open`+`RoundRobin`) has no valid intermediate state for
+    /// `set_game_mode`/`set_shuffle_type` to pass through one at a time.
+    pub fn set_game_mode_and_shuffle_type(
+        &mut self,
+        game_mode: GameMode,
+        shuffle_type: ShuffleType,
+    ) -> HttpResult<()> {
+        game_mode.validate_players_per_team(*self.settings.players_per_team())?;
+        game_mode.validate_shuffle_type(shuffle_type)?;
+        self.game_mode = game_mode;
+        self.shuffle_type = shuffle_type;
+        self.updated_at = Some(Utc::now());
+
+        Ok(())
     }
 
     pub fn set_player_ids(&mut self, player_ids: Vec<Uuid>) {
@@ -231,6 +296,118 @@ mod tests {
         odd_settings.players_per_team = 3;
 
         let err = session.set_settings(odd_settings).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_new_session_rejects_open_mode_with_king_and_queen_shuffle() {
+        let err = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Open,
+            ShuffleType::KingAndQueen,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_new_session_rejects_round_robin_shuffle_with_non_open_mode() {
+        let err = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Male,
+            ShuffleType::RoundRobin,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_new_session_allows_open_mode_with_round_robin_shuffle() {
+        let session = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Open,
+            ShuffleType::RoundRobin,
+        );
+
+        assert!(session.is_ok());
+    }
+
+    #[test]
+    fn test_set_game_mode_rejects_open_when_current_shuffle_is_king_and_queen() {
+        let mut session = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Male,
+            ShuffleType::KingAndQueen,
+        )
+        .unwrap();
+
+        let err = session.set_game_mode(GameMode::Open).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_set_shuffle_type_rejects_round_robin_when_current_mode_is_not_open() {
+        let mut session = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Male,
+            ShuffleType::KingAndQueen,
+        )
+        .unwrap();
+
+        let err = session
+            .set_shuffle_type(ShuffleType::RoundRobin)
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_set_game_mode_and_shuffle_type_together_allows_swapping_to_open_round_robin() {
+        let mut session = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Male,
+            ShuffleType::KingAndQueen,
+        )
+        .unwrap();
+
+        session
+            .set_game_mode_and_shuffle_type(GameMode::Open, ShuffleType::RoundRobin)
+            .unwrap();
+
+        assert_eq!(*session.game_mode(), GameMode::Open);
+        assert_eq!(*session.shuffle_type(), ShuffleType::RoundRobin);
+    }
+
+    #[test]
+    fn test_set_game_mode_and_shuffle_type_rejects_mismatched_pair() {
+        let mut session = Session::new(
+            date(),
+            SessionSettings::default(),
+            2,
+            GameMode::Male,
+            ShuffleType::KingAndQueen,
+        )
+        .unwrap();
+
+        let err = session
+            .set_game_mode_and_shuffle_type(GameMode::Open, ShuffleType::KingAndQueen)
+            .unwrap_err();
 
         assert_eq!(err.kind, HttpErrorKind::BadRequest);
     }

--- a/api/src/modules/matchmaking/domain/team_drawer.rs
+++ b/api/src/modules/matchmaking/domain/team_drawer.rs
@@ -102,6 +102,11 @@ impl TeamDrawer {
                 history,
             )),
             GameMode::Mixed => Ok(self.draw_mixed(players, history)),
+            GameMode::Open => Ok(Self::draw_pool_greedy(
+                Self::player_ids_all(players),
+                self.players_per_team.into(),
+                history,
+            )),
         }
     }
 
@@ -202,6 +207,10 @@ impl TeamDrawer {
             .filter(|player| *player.gender() == gender)
             .map(|player| *player.id())
             .collect()
+    }
+
+    fn player_ids_all(players: &[Player]) -> Vec<Uuid> {
+        players.iter().map(|player| *player.id()).collect()
     }
 }
 
@@ -373,6 +382,27 @@ mod tests {
             teams[0].iter().collect::<HashSet<_>>(),
             ids.iter().collect::<HashSet<_>>()
         );
+    }
+
+    #[test]
+    fn test_draw_open_mode_ignores_gender_and_pairs_everyone() {
+        let players = vec![
+            player(Gender::Male),
+            player(Gender::Male),
+            player(Gender::Female),
+            player(Gender::Female),
+        ];
+
+        let teams = TeamDrawer::new(GameMode::Open, 2)
+            .draw(&players, &PartnerHistory::empty())
+            .unwrap();
+
+        let total_players: usize = teams.iter().map(Vec::len).sum();
+        assert_eq!(total_players, 4);
+        assert_eq!(teams.len(), 2);
+        for team in teams {
+            assert_eq!(team.len(), 2);
+        }
     }
 
     #[test]

--- a/api/src/modules/matchmaking/domain/team_queue.rs
+++ b/api/src/modules/matchmaking/domain/team_queue.rs
@@ -36,6 +36,10 @@ impl TeamQueueManager {
     /// versus starts a new one). Returns every team that was created or
     /// modified, for the caller to persist — teams left untouched are not
     /// included.
+    ///
+    /// When `game_mode` is `GameMode::Open`, a freed player only completes
+    /// an incomplete team when that pairing is brand new — it opens a new
+    /// team instead of repeating a pairing while a fresh alternative exists.
     pub fn release_players(
         &self,
         waiting_teams: &[Team],
@@ -60,6 +64,13 @@ impl TeamQueueManager {
                 .filter(|&index| {
                     !pending[index].is_complete(self.players_per_team)
                         && self.needs_gender(&pending[index], gender, players)
+                })
+                .filter(|&index| {
+                    !self.game_mode.requires_fresh_partner()
+                        || !pending[index]
+                            .player_ids()
+                            .iter()
+                            .any(|member| history.have_played_together(*member, player_id))
                 })
                 .min_by_key(|&index| {
                     pending[index]
@@ -135,6 +146,7 @@ impl TeamQueueManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::modules::matchmaking::domain::matches::Match;
 
     fn player(gender: Gender) -> Player {
         Player::new("Player".to_string(), gender)
@@ -227,6 +239,91 @@ mod tests {
             .find(|team| *team.id() != *incomplete_team.id())
             .expect("the freed male starts its own incomplete team");
         assert_eq!(new_incomplete.player_ids(), &vec![*freed_male.id()]);
+    }
+
+    #[test]
+    fn test_release_players_in_open_mode_opens_a_new_team_instead_of_repeating_a_pairing() {
+        let session_id = Uuid::new_v4();
+        let waiting_player = player(Gender::Male);
+        let already_played_with_waiting = player(Gender::Male);
+        let fresh_player = player(Gender::Female);
+        let players = vec![
+            waiting_player.clone(),
+            already_played_with_waiting.clone(),
+            fresh_player.clone(),
+        ];
+
+        let incomplete_team = Team::new(session_id, vec![*waiting_player.id()]);
+
+        let played_team = Team::new(
+            session_id,
+            vec![*waiting_player.id(), *already_played_with_waiting.id()],
+        );
+        let played_match = Match::new(session_id, 1, *played_team.id(), Uuid::new_v4()).unwrap();
+        let history = PartnerHistory::from_matches(&[played_team], &[played_match]);
+
+        let manager = TeamQueueManager::new(session_id, GameMode::Open, 2);
+
+        let changed = manager.release_players(
+            &[incomplete_team.clone()],
+            &[*already_played_with_waiting.id(), *fresh_player.id()],
+            &players,
+            &history,
+        );
+
+        let completed = changed
+            .iter()
+            .find(|team| *team.id() == *incomplete_team.id())
+            .expect("the waiting player should only be completed by a fresh partner");
+        assert!(completed.player_ids().contains(fresh_player.id()));
+        assert!(!completed
+            .player_ids()
+            .contains(already_played_with_waiting.id()));
+
+        let new_incomplete = changed
+            .iter()
+            .find(|team| *team.id() != *incomplete_team.id())
+            .expect(
+                "the player who already partnered with the waiting player should start a new team",
+            );
+        assert_eq!(
+            new_incomplete.player_ids(),
+            &vec![*already_played_with_waiting.id()]
+        );
+    }
+
+    #[test]
+    fn test_release_players_in_open_mode_starts_a_new_team_when_the_only_incomplete_team_would_repeat(
+    ) {
+        let session_id = Uuid::new_v4();
+        let waiting_player = player(Gender::Male);
+        let already_played_with_waiting = player(Gender::Male);
+        let players = vec![waiting_player.clone(), already_played_with_waiting.clone()];
+
+        let incomplete_team = Team::new(session_id, vec![*waiting_player.id()]);
+
+        let played_team = Team::new(
+            session_id,
+            vec![*waiting_player.id(), *already_played_with_waiting.id()],
+        );
+        let played_match = Match::new(session_id, 1, *played_team.id(), Uuid::new_v4()).unwrap();
+        let history = PartnerHistory::from_matches(&[played_team], &[played_match]);
+
+        let manager = TeamQueueManager::new(session_id, GameMode::Open, 2);
+
+        let changed = manager.release_players(
+            &[incomplete_team.clone()],
+            &[*already_played_with_waiting.id()],
+            &players,
+            &history,
+        );
+
+        assert_eq!(changed.len(), 1);
+        assert_ne!(*changed[0].id(), *incomplete_team.id());
+        assert_eq!(
+            changed[0].player_ids(),
+            &vec![*already_played_with_waiting.id()]
+        );
     }
 
     #[test]

--- a/api/src/modules/matchmaking/handler/session.rs
+++ b/api/src/modules/matchmaking/handler/session.rs
@@ -68,12 +68,10 @@ impl SessionHandler for SessionHandlerImpl {
             session.set_available_courts(available_courts);
         }
 
-        if let Some(game_mode) = request.game_mode {
-            session.set_game_mode(game_mode)?;
-        }
-
-        if let Some(shuffle_type) = request.shuffle_type {
-            session.set_shuffle_type(shuffle_type);
+        if request.game_mode.is_some() || request.shuffle_type.is_some() {
+            let game_mode = request.game_mode.unwrap_or(*session.game_mode());
+            let shuffle_type = request.shuffle_type.unwrap_or(*session.shuffle_type());
+            session.set_game_mode_and_shuffle_type(game_mode, shuffle_type)?;
         }
 
         if let Some(player_ids) = request.player_ids {


### PR DESCRIPTION
Adds GameMode::Open + ShuffleType::RoundRobin: a session mode that ignores gender when forming teams and, in the ongoing queue, never repeats a partner pairing while a fresh alternative is available, opening a new team instead. The initial draw stays random, same as the other modes, since partner history is always empty at that point.

Open and RoundRobin are only valid combined with each other, validated as a pair rather than field-by-field so update_session can swap both at once without passing through an invalid intermediate state.