### PR TITLE
fix(matchmaking): scope manual team creation to available session pla…

### DIFF
--- a/.claude/skills/gb-matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/gb-matchmaking-business-rules/SKILL.md
@@ -137,7 +137,17 @@ Validado por `Match::new`/`Match::finish`/`MatchStartValidator`
 `MatchHandlerImpl::create_match`/`report_match_result` via `POST
 /matchmaking/matches/` e `POST /matchmaking/matches/{match_id}/result`.
 
-Restrições de duplicidade de jogador validadas por
+- `POST /matchmaking/teams/` (`create_team`) é a via manual de entrada de
+  `Team`: independente do `GameMode`/`ShuffleType` da `Session` (esses só
+  restringem o sorteio automático e a rotação da fila, nunca a montagem
+  manual), permite montar um time escolhendo jogadores específicos — usado
+  como contingência quando o sorteio/fila automáticos precisam de correção
+  manual. Ainda assim exige que todo `player_id` esteja confirmado em
+  `Session::player_ids` e que nenhum já esteja em outra `Team` **ativa**
+  (`Waiting`/`Holding`) da mesma `Session`; jogadores de uma `Team`
+  `Disbanded` já estão livres de novo e não bloqueiam.
+
+Restrições de duplicidade/elegibilidade de jogador validadas por
 `TeamValidator::validate_new_team` (`api/src/modules/matchmaking/domain/team.rs`),
 chamado tanto por `TeamHandlerImpl::create_team` quanto por
 `TeamHandlerImpl::draw_teams`.
@@ -194,6 +204,15 @@ removido de uma Session após os times já terem sido sorteados, etc.
 
 ## Histórico de mudanças
 
+- 2026-08-15 — `create_team` (entrada manual de `Team`) passa a validar que
+  todo `player_id` está confirmado em `Session::player_ids`
+  (`HttpError::bad_request` caso contrário), e o check de "já está em outro
+  time" passa a ignorar `Team`s `Disbanded` (antes bloqueava indevidamente
+  a reentrada manual de um jogador cujo time anterior já havia se desfeito
+  — exatamente o cenário de contingência que essa rota existe pra cobrir).
+  Confirma que a rota continua deliberadamente sem checagem de `GameMode`/
+  `ShuffleType`: a montagem manual é independente da configuração da
+  `Session`.
 - 2026-08-14 — adicionado `GameMode::Open` (ignora gênero na formação de
   times) e `ShuffleType::RoundRobin` (mesma mecânica de fila/quadra do
   `KingAndQueen`, mas a fila prioriza fortemente duplas inéditas ao

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -101,28 +101,40 @@ getters! {
     }
 }
 
-/// Centralizes the validation rules for forming a `Team` within a `Session`.
-/// Bound to a `session_id` at construction so it always scopes the
-/// "player already in another team" check to that session, regardless of
-/// what `existing_teams` the caller passes in.
+/// Centralizes the validation rules for forming a `Team` within a `Session`,
+/// including the manual (contingency) path: an operator picking specific
+/// players to force a team into the queue, regardless of the session's
+/// `GameMode`/`ShuffleType` — those only constrain the automated draw and
+/// queue rotation, never a manually assembled team.
+/// Bound to a `session_id` and that session's confirmed `player_ids` at
+/// construction so it always scopes its checks to that session, regardless
+/// of what `existing_teams` the caller passes in.
 pub struct TeamValidator {
     session_id: Uuid,
+    session_player_ids: Vec<Uuid>,
 }
 
 impl TeamValidator {
-    pub fn new(session_id: Uuid) -> Self {
-        Self { session_id }
+    pub fn new(session_id: Uuid, session_player_ids: Vec<Uuid>) -> Self {
+        Self {
+            session_id,
+            session_player_ids,
+        }
     }
 
-    /// A player cannot repeat within the same team, nor be in two teams of
-    /// the same session at the same time.
+    /// A player cannot repeat within the same team, must be a player
+    /// confirmed for the session, and cannot be in another active
+    /// (non-disbanded) team of the same session at the same time. A
+    /// disbanded team's players are free again, so they never block a new
+    /// team here.
     pub fn validate_new_team(
         &self,
         existing_teams: &[Team],
         player_ids: &[Uuid],
     ) -> HttpResult<()> {
         Self::reject_duplicate_players_in_team(player_ids)?;
-        self.reject_players_already_in_session(existing_teams, player_ids)?;
+        self.reject_players_not_confirmed_in_session(player_ids)?;
+        self.reject_players_already_in_active_team(existing_teams, player_ids)?;
 
         Ok(())
     }
@@ -141,14 +153,27 @@ impl TeamValidator {
         Ok(())
     }
 
-    fn reject_players_already_in_session(
+    fn reject_players_not_confirmed_in_session(&self, player_ids: &[Uuid]) -> HttpResult<()> {
+        if let Some(player_id) = player_ids
+            .iter()
+            .find(|player_id| !self.session_player_ids.contains(player_id))
+        {
+            return Err(Box::new(HttpError::bad_request(format!(
+                "Player {player_id} is not a confirmed player of this session"
+            ))));
+        }
+
+        Ok(())
+    }
+
+    fn reject_players_already_in_active_team(
         &self,
         existing_teams: &[Team],
         player_ids: &[Uuid],
     ) -> HttpResult<()> {
         let players_in_session: HashSet<&Uuid> = existing_teams
             .iter()
-            .filter(|team| team.session_id() == &self.session_id)
+            .filter(|team| team.session_id() == &self.session_id && !team.is_disbanded())
             .flat_map(|team| team.player_ids())
             .collect();
 
@@ -234,25 +259,39 @@ mod tests {
 
     #[test]
     fn test_validate_new_team_with_no_existing_teams() {
-        let validator = TeamValidator::new(Uuid::new_v4());
         let player_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+        let validator = TeamValidator::new(Uuid::new_v4(), player_ids.clone());
 
         assert!(validator.validate_new_team(&[], &player_ids).is_ok());
     }
 
     #[test]
     fn test_validate_new_team_with_single_player() {
-        let validator = TeamValidator::new(Uuid::new_v4());
         let player_ids = vec![Uuid::new_v4()];
+        let validator = TeamValidator::new(Uuid::new_v4(), player_ids.clone());
 
         assert!(validator.validate_new_team(&[], &player_ids).is_ok());
     }
 
     #[test]
     fn test_validate_new_team_rejects_duplicated_player_in_same_team() {
-        let validator = TeamValidator::new(Uuid::new_v4());
         let player_id = Uuid::new_v4();
         let player_ids = vec![player_id, player_id];
+        let validator = TeamValidator::new(Uuid::new_v4(), player_ids.clone());
+
+        let err = validator.validate_new_team(&[], &player_ids).unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn test_validate_new_team_rejects_player_not_confirmed_in_session() {
+        let session_id = Uuid::new_v4();
+        let confirmed_player = Uuid::new_v4();
+        let outsider_player = Uuid::new_v4();
+
+        let validator = TeamValidator::new(session_id, vec![confirmed_player]);
+        let player_ids = vec![confirmed_player, outsider_player];
 
         let err = validator.validate_new_team(&[], &player_ids).unwrap_err();
 
@@ -263,10 +302,14 @@ mod tests {
     fn test_validate_new_team_rejects_player_already_in_another_team_of_same_session() {
         let session_id = Uuid::new_v4();
         let repeated_player = Uuid::new_v4();
+        let new_player = Uuid::new_v4();
 
-        let validator = TeamValidator::new(session_id);
+        let validator = TeamValidator::new(
+            session_id,
+            vec![repeated_player, Uuid::new_v4(), new_player],
+        );
         let existing_team = Team::new(session_id, vec![repeated_player, Uuid::new_v4()]);
-        let player_ids = vec![repeated_player, Uuid::new_v4()];
+        let player_ids = vec![repeated_player, new_player];
 
         let err = validator
             .validate_new_team(std::slice::from_ref(&existing_team), &player_ids)
@@ -275,12 +318,33 @@ mod tests {
         assert_eq!(err.kind, HttpErrorKind::Conflict);
     }
 
+    /// A disbanded team's players are free again — they must not block a
+    /// manually created team, which is exactly the contingency scenario a
+    /// manual team is meant to unblock (e.g. re-forming a team right after
+    /// its previous one lost and was disbanded).
+    #[test]
+    fn test_validate_new_team_ignores_players_from_a_disbanded_team() {
+        let session_id = Uuid::new_v4();
+        let freed_player = Uuid::new_v4();
+        let partner = Uuid::new_v4();
+
+        let validator = TeamValidator::new(session_id, vec![freed_player, partner]);
+        let mut disbanded_team = Team::new(session_id, vec![freed_player, Uuid::new_v4()]);
+        disbanded_team.disband();
+        let player_ids = vec![freed_player, partner];
+
+        let result =
+            validator.validate_new_team(std::slice::from_ref(&disbanded_team), &player_ids);
+
+        assert!(result.is_ok());
+    }
+
     #[test]
     fn test_validate_new_team_allows_when_no_players_overlap_with_existing_team() {
         let session_id = Uuid::new_v4();
-        let validator = TeamValidator::new(session_id);
-        let existing_team = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
         let player_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+        let existing_team = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+        let validator = TeamValidator::new(session_id, player_ids.clone());
 
         let result = validator.validate_new_team(std::slice::from_ref(&existing_team), &player_ids);
 
@@ -295,11 +359,11 @@ mod tests {
         let session_id = Uuid::new_v4();
         let other_session_id = Uuid::new_v4();
         let shared_player = Uuid::new_v4();
+        let player_ids = vec![shared_player, Uuid::new_v4()];
 
-        let validator = TeamValidator::new(session_id);
+        let validator = TeamValidator::new(session_id, player_ids.clone());
         let team_from_other_session =
             Team::new(other_session_id, vec![shared_player, Uuid::new_v4()]);
-        let player_ids = vec![shared_player, Uuid::new_v4()];
 
         let result = validator
             .validate_new_team(std::slice::from_ref(&team_from_other_session), &player_ids);
@@ -314,12 +378,13 @@ mod tests {
         let session_id = Uuid::new_v4();
         let other_session_id = Uuid::new_v4();
         let repeated_player = Uuid::new_v4();
+        let new_player = Uuid::new_v4();
 
-        let validator = TeamValidator::new(session_id);
+        let validator = TeamValidator::new(session_id, vec![repeated_player, new_player]);
         let team_in_same_session = Team::new(session_id, vec![repeated_player, Uuid::new_v4()]);
         let team_in_other_session =
             Team::new(other_session_id, vec![repeated_player, Uuid::new_v4()]);
-        let player_ids = vec![repeated_player, Uuid::new_v4()];
+        let player_ids = vec![repeated_player, new_player];
 
         let err = validator
             .validate_new_team(&[team_in_same_session, team_in_other_session], &player_ids)

--- a/api/src/modules/matchmaking/handler/team.rs
+++ b/api/src/modules/matchmaking/handler/team.rs
@@ -20,6 +20,14 @@ use crate::modules::matchmaking::{
 
 #[async_trait]
 pub trait TeamHandler {
+    /// Manually forms a team from players confirmed in the session, entering
+    /// it into the queue as `Waiting` — the contingency path for an operator
+    /// to force a team in (e.g. the automated draw/rotation got stuck or
+    /// needs a manual correction), regardless of the session's `GameMode` or
+    /// `ShuffleType`: those only constrain the automated draw and queue
+    /// rotation, never a manually assembled team. Still enforces that every
+    /// player is confirmed in the session and not currently in another
+    /// active (non-disbanded) team of it.
     async fn create_team(&self, request: CreateTeamRequest) -> HttpResult<Team>;
 
     async fn list_teams_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Team>>;
@@ -56,12 +64,18 @@ pub struct TeamHandlerImpl {
 #[async_trait]
 impl TeamHandler for TeamHandlerImpl {
     async fn create_team(&self, request: CreateTeamRequest) -> HttpResult<Team> {
+        let session = self
+            .session_repository
+            .get(&request.session_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Session", request.session_id)))?;
+
         let existing_teams = self
             .team_repository
             .list_by_session(&request.session_id)
             .await?;
 
-        TeamValidator::new(request.session_id)
+        TeamValidator::new(request.session_id, session.player_ids().clone())
             .validate_new_team(&existing_teams, &request.player_ids)?;
 
         let team = Team::new(request.session_id, request.player_ids);
@@ -105,7 +119,7 @@ impl TeamHandler for TeamHandlerImpl {
             )));
         }
 
-        let validator = TeamValidator::new(session_id);
+        let validator = TeamValidator::new(session_id, session.player_ids().clone());
         let mut created_teams = Vec::with_capacity(drawn_teams.len());
 
         for player_ids in drawn_teams {


### PR DESCRIPTION
…yers

create_team now requires every player to be confirmed in the session and ignores disbanded teams when checking for conflicts, so a player freed by a disbanded team can be manually re-entered right away. Fixes the gap that blocked using this route as a contingency to fix the queue by hand.