### PR TITLE
feat(matchmaking): add manual priority team to jump the queue

### DIFF
--- a/.claude/skills/gb-matchmaking-business-rules/SKILL.md
+++ b/.claude/skills/gb-matchmaking-business-rules/SKILL.md
@@ -98,6 +98,21 @@ habilidade, histórico de parceria, aleatoriedade controlada, etc.
   (`api/src/modules/matchmaking/handler/team.rs`), chamado por
   `MatchHandlerImpl::report_match_result`
   (`api/src/modules/matchmaking/handler/matches.rs`).
+- **Entrada prioritária manual:** `POST /matchmaking/teams/priority`
+  (`TeamHandlerImpl::create_priority_team`) monta uma `Team` a partir dos
+  jogadores informados e a marca com `Team::with_priority`, o que a coloca
+  na frente de toda `Team` não-prioritária em
+  `TeamQueueManager::next_complete_teams` — é o próximo desafiante
+  garantido assim que uma quadra ficar livre (não necessariamente *essa*
+  quadra específica, se mais de uma abrir ao mesmo tempo). Diferente de
+  `create_team`, essa via aceita puxar um jogador que já está em outra
+  `Team` `Waiting` (contanto que ela não esteja disputando um `Match` em
+  andamento): a `Team` de origem é desfeita e o(s) parceiro(s) que sobrou(aram)
+  sem dupla volta(m) pra fila normalmente, via
+  `TeamQueueManager::release_players` — o mesmo caminho usado para
+  jogadores liberados por resultado de partida. Um jogador numa `Team`
+  `Holding` (segurando quadra) ou já ocupada num `Match` não pode ser
+  puxado. Validado por `TeamValidator::validate_priority_team`.
 
 ## Restrições
 
@@ -160,7 +175,12 @@ ser excedidas, etc.
 
 ## Prioridades
 
-_A definir._
+- Uma `Team` marcada `priority` (via `POST /matchmaking/teams/priority`)
+  sempre entra em quadra antes de qualquer `Team` não-prioritária, mesmo
+  que essa última esteja esperando há mais tempo — a ordem por
+  `created_at` (FIFO) só decide empate dentro do mesmo grupo (entre
+  prioritárias, ou entre não-prioritárias). Ver
+  `TeamQueueManager::next_complete_teams`.
 
 <!--
 Quando múltiplos critérios de pareamento entram em conflito, qual prevalece.
@@ -204,6 +224,18 @@ removido de uma Session após os times já terem sido sorteados, etc.
 
 ## Histórico de mudanças
 
+- 2026-08-15 — nova rota `POST /matchmaking/teams/priority`
+  (`TeamHandlerImpl::create_priority_team`) para o operador informar
+  manualmente qual dupla joga a seguir, ignorando a fila FIFO normal —
+  caso de uso: uma quadra está rodando e o operador quer garantir quem
+  entra assim que ela liberar, sem depender do sorteio/fila automáticos.
+  `Team` ganha o campo `priority` (`Team::with_priority`), que
+  `TeamQueueManager::next_complete_teams` passa a priorizar sobre a ordem
+  por `created_at`. Diferente de `create_team`, essa via pode puxar um
+  jogador de outra `Team` `Waiting` não ocupada em partida — a `Team` de
+  origem é desfeita e o parceiro que sobra é re-inserido na fila via
+  `TeamQueueManager::release_players`, igual a um jogador liberado por
+  resultado de partida.
 - 2026-08-15 — `create_team` (entrada manual de `Team`) passa a validar que
   todo `player_id` está confirmado em `Session::player_ids`
   (`HttpError::bad_request` caso contrário), e o check de "já está em outro

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -28,6 +28,9 @@ pub struct Team {
     player_ids: Vec<Uuid>,
     status: TeamStatus,
     consecutive_wins: u8,
+    /// Set by `Team::with_priority` — jumps this team ahead of every
+    /// non-priority team in `TeamQueueManager::next_complete_teams`.
+    priority: bool,
     created_at: DateTime<Utc>,
 }
 
@@ -43,8 +46,18 @@ impl Team {
             player_ids,
             status: TeamStatus::Waiting,
             consecutive_wins: 0,
+            priority: false,
             created_at: Utc::now(),
         }
+    }
+
+    /// Marks this team to jump the queue: the manual "who plays next"
+    /// override for when an operator needs to put a specific pairing on
+    /// court next, regardless of how long everyone else has been waiting.
+    /// See `TeamQueueManager::next_complete_teams`.
+    pub fn with_priority(mut self) -> Self {
+        self.priority = true;
+        self
     }
 
     pub fn is_waiting(&self) -> bool {
@@ -57,6 +70,10 @@ impl Team {
 
     pub fn is_disbanded(&self) -> bool {
         self.status == TeamStatus::Disbanded
+    }
+
+    pub fn is_priority(&self) -> bool {
+        self.priority
     }
 
     /// Whether this team has as many players as a full team needs.
@@ -137,6 +154,71 @@ impl TeamValidator {
         self.reject_players_already_in_active_team(existing_teams, player_ids)?;
 
         Ok(())
+    }
+
+    /// Validates a manual "priority" team — the operator override to put a
+    /// specific pairing on court next (see `Team::with_priority`). Same
+    /// duplicate/session-membership checks as `validate_new_team`, but here
+    /// a player already in another `Waiting` team is allowed *if* that team
+    /// isn't tied up in an in-progress match: pulling them out to jump this
+    /// pairing to the front of the queue is exactly what this path is for.
+    /// A player in a `Holding` team, or one that's playing right now, can't
+    /// be pulled — that would strand a court still being defended or an
+    /// in-progress match.
+    ///
+    /// Returns, for each distinct origin team a player was pulled from, that
+    /// team paired with the ids of its now partner-less remaining players —
+    /// the caller must disband the origin team and re-slot those remaining
+    /// players back into the queue (see `TeamQueueManager::release_players`).
+    pub fn validate_priority_team(
+        &self,
+        existing_teams: &[Team],
+        busy_team_ids: &HashSet<Uuid>,
+        player_ids: &[Uuid],
+    ) -> HttpResult<Vec<(Team, Vec<Uuid>)>> {
+        Self::reject_duplicate_players_in_team(player_ids)?;
+        self.reject_players_not_confirmed_in_session(player_ids)?;
+        self.collect_broken_origin_teams(existing_teams, busy_team_ids, player_ids)
+    }
+
+    fn collect_broken_origin_teams(
+        &self,
+        existing_teams: &[Team],
+        busy_team_ids: &HashSet<Uuid>,
+        player_ids: &[Uuid],
+    ) -> HttpResult<Vec<(Team, Vec<Uuid>)>> {
+        let mut broken: Vec<(Team, Vec<Uuid>)> = Vec::new();
+
+        for player_id in player_ids {
+            let Some(owner) = existing_teams.iter().find(|team| {
+                team.session_id() == &self.session_id
+                    && !team.is_disbanded()
+                    && team.player_ids().contains(player_id)
+            }) else {
+                continue;
+            };
+
+            if !owner.is_waiting() || busy_team_ids.contains(owner.id()) {
+                return Err(Box::new(HttpError::conflict(format!(
+                    "Player {player_id} is in a team that can't be broken up right now"
+                ))));
+            }
+
+            match broken.iter_mut().find(|(team, _)| team.id() == owner.id()) {
+                Some((_, remaining)) => remaining.retain(|id| id != player_id),
+                None => {
+                    let remaining = owner
+                        .player_ids()
+                        .iter()
+                        .copied()
+                        .filter(|id| id != player_id)
+                        .collect();
+                    broken.push((owner.clone(), remaining));
+                }
+            }
+        }
+
+        Ok(broken)
     }
 
     fn reject_duplicate_players_in_team(player_ids: &[Uuid]) -> HttpResult<()> {
@@ -391,5 +473,136 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_with_priority_marks_the_team_as_priority() {
+        let team = Team::new(Uuid::new_v4(), vec![Uuid::new_v4(), Uuid::new_v4()]).with_priority();
+
+        assert!(team.is_priority());
+    }
+
+    #[test]
+    fn test_validate_priority_team_allows_a_player_free_in_the_session() {
+        let session_id = Uuid::new_v4();
+        let player_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+        let validator = TeamValidator::new(session_id, player_ids.clone());
+
+        let broken = validator
+            .validate_priority_team(&[], &HashSet::new(), &player_ids)
+            .unwrap();
+
+        assert!(broken.is_empty());
+    }
+
+    /// The whole point of the priority path: pulling one player out of a
+    /// `Waiting` team that isn't mid-match must report that team so the
+    /// caller can disband it and re-slot its now partner-less teammate.
+    #[test]
+    fn test_validate_priority_team_reports_the_origin_team_of_a_stolen_player() {
+        let session_id = Uuid::new_v4();
+        let stolen_player = Uuid::new_v4();
+        let stranded_partner = Uuid::new_v4();
+        let new_partner = Uuid::new_v4();
+
+        let origin_team = Team::new(session_id, vec![stolen_player, stranded_partner]);
+        let origin_team_id = *origin_team.id();
+        let validator = TeamValidator::new(
+            session_id,
+            vec![stolen_player, stranded_partner, new_partner],
+        );
+        let player_ids = vec![stolen_player, new_partner];
+
+        let broken = validator
+            .validate_priority_team(std::slice::from_ref(&origin_team), &HashSet::new(), &player_ids)
+            .unwrap();
+
+        assert_eq!(broken.len(), 1);
+        let (reported_team, remaining) = &broken[0];
+        assert_eq!(reported_team.id(), &origin_team_id);
+        assert_eq!(remaining, &vec![stranded_partner]);
+    }
+
+    /// Stealing both members of a pair must report that origin team with no
+    /// remaining players — nothing left to re-slot, just disband it.
+    #[test]
+    fn test_validate_priority_team_reports_empty_remaining_when_both_players_are_stolen() {
+        let session_id = Uuid::new_v4();
+        let player_a = Uuid::new_v4();
+        let player_b = Uuid::new_v4();
+
+        let origin_team = Team::new(session_id, vec![player_a, player_b]);
+        let validator = TeamValidator::new(session_id, vec![player_a, player_b]);
+
+        let broken = validator
+            .validate_priority_team(
+                std::slice::from_ref(&origin_team),
+                &HashSet::new(),
+                &[player_a, player_b],
+            )
+            .unwrap();
+
+        assert_eq!(broken.len(), 1);
+        assert!(broken[0].1.is_empty());
+    }
+
+    #[test]
+    fn test_validate_priority_team_rejects_a_player_from_a_holding_team() {
+        let session_id = Uuid::new_v4();
+        let player_id = Uuid::new_v4();
+        let new_partner = Uuid::new_v4();
+        let mut holding_team = Team::new(session_id, vec![player_id, Uuid::new_v4()]);
+        holding_team.register_win();
+        let validator = TeamValidator::new(session_id, vec![player_id, new_partner]);
+
+        let err = validator
+            .validate_priority_team(
+                std::slice::from_ref(&holding_team),
+                &HashSet::new(),
+                &[player_id, new_partner],
+            )
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_validate_priority_team_rejects_a_player_from_a_busy_team() {
+        let session_id = Uuid::new_v4();
+        let player_id = Uuid::new_v4();
+        let new_partner = Uuid::new_v4();
+        let busy_team = Team::new(session_id, vec![player_id, Uuid::new_v4()]);
+        let busy_team_id = *busy_team.id();
+        let validator = TeamValidator::new(session_id, vec![player_id, new_partner]);
+
+        let err = validator
+            .validate_priority_team(
+                std::slice::from_ref(&busy_team),
+                &HashSet::from([busy_team_id]),
+                &[player_id, new_partner],
+            )
+            .unwrap_err();
+
+        assert_eq!(err.kind, HttpErrorKind::Conflict);
+    }
+
+    #[test]
+    fn test_validate_priority_team_ignores_a_disbanded_teammate() {
+        let session_id = Uuid::new_v4();
+        let player_id = Uuid::new_v4();
+        let new_partner = Uuid::new_v4();
+        let mut disbanded_team = Team::new(session_id, vec![player_id, Uuid::new_v4()]);
+        disbanded_team.disband();
+        let validator = TeamValidator::new(session_id, vec![player_id, new_partner]);
+
+        let broken = validator
+            .validate_priority_team(
+                std::slice::from_ref(&disbanded_team),
+                &HashSet::new(),
+                &[player_id, new_partner],
+            )
+            .unwrap();
+
+        assert!(broken.is_empty());
     }
 }

--- a/api/src/modules/matchmaking/domain/team_queue.rs
+++ b/api/src/modules/matchmaking/domain/team_queue.rs
@@ -99,8 +99,10 @@ impl TeamQueueManager {
             .collect()
     }
 
-    /// The next `count` complete teams in the queue, oldest first — the
-    /// ones that should auto-fill a court that just freed up.
+    /// The next `count` complete teams in the queue — priority teams
+    /// (`Team::with_priority`, the manual "who plays next" override) always
+    /// come first, oldest-priority-first; then everyone else, oldest first.
+    /// These are the ones that should auto-fill a court that just freed up.
     pub fn next_complete_teams<'a>(
         &self,
         waiting_teams: &'a [Team],
@@ -110,7 +112,7 @@ impl TeamQueueManager {
             .iter()
             .filter(|team| team.is_waiting() && team.is_complete(self.players_per_team))
             .collect();
-        complete.sort_by_key(|team| *team.created_at());
+        complete.sort_by_key(|team| (!team.is_priority(), *team.created_at()));
 
         complete.into_iter().take(count).collect()
     }
@@ -357,5 +359,24 @@ mod tests {
         let next = manager.next_complete_teams(&waiting_teams, 1);
 
         assert!(next.is_empty());
+    }
+
+    /// A priority team jumps every non-priority team, even ones that have
+    /// been waiting longer.
+    #[test]
+    fn test_next_complete_teams_puts_priority_teams_first() {
+        let session_id = Uuid::new_v4();
+        let manager = TeamQueueManager::new(session_id, GameMode::Male, 2);
+
+        let long_waiting = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let priority = Team::new(session_id, vec![Uuid::new_v4(), Uuid::new_v4()]).with_priority();
+
+        let waiting_teams = vec![long_waiting.clone(), priority.clone()];
+
+        let next = manager.next_complete_teams(&waiting_teams, 2);
+
+        assert_eq!(*next[0].id(), *priority.id());
+        assert_eq!(*next[1].id(), *long_waiting.id());
     }
 }

--- a/api/src/modules/matchmaking/handler/team.rs
+++ b/api/src/modules/matchmaking/handler/team.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use http_error::{HttpError, HttpResult};
@@ -29,6 +29,16 @@ pub trait TeamHandler {
     /// player is confirmed in the session and not currently in another
     /// active (non-disbanded) team of it.
     async fn create_team(&self, request: CreateTeamRequest) -> HttpResult<Team>;
+
+    /// Manual "who plays next" override: forms a team from the given
+    /// players and jumps it to the front of the waiting queue
+    /// (`Team::with_priority`), so it's the next one an idle court pulls
+    /// in — ahead of everyone who's been waiting longer. Unlike
+    /// `create_team`, a player already in another `Waiting` team (not
+    /// mid-match) can be pulled into this one: that team is disbanded and
+    /// its now partner-less remaining player(s) are re-slotted back into
+    /// the queue, exactly like a freed player after a match result.
+    async fn create_priority_team(&self, request: CreateTeamRequest) -> HttpResult<Team>;
 
     async fn list_teams_by_session(&self, session_id: Uuid) -> HttpResult<Vec<Team>>;
 
@@ -79,6 +89,84 @@ impl TeamHandler for TeamHandlerImpl {
             .validate_new_team(&existing_teams, &request.player_ids)?;
 
         let team = Team::new(request.session_id, request.player_ids);
+
+        self.team_repository.insert(team).await
+    }
+
+    async fn create_priority_team(&self, request: CreateTeamRequest) -> HttpResult<Team> {
+        let session = self
+            .session_repository
+            .get(&request.session_id)
+            .await?
+            .ok_or_else(|| Box::new(HttpError::not_found("Session", request.session_id)))?;
+
+        let existing_teams = self
+            .team_repository
+            .list_by_session(&request.session_id)
+            .await?;
+        let session_matches = self
+            .match_repository
+            .list_by_session(&request.session_id)
+            .await?;
+        let busy_team_ids = Match::busy_team_ids(&session_matches);
+
+        let broken_origin_teams =
+            TeamValidator::new(request.session_id, session.player_ids().clone())
+                .validate_priority_team(&existing_teams, &busy_team_ids, &request.player_ids)?;
+
+        let history = PartnerHistory::from_matches(&existing_teams, &session_matches);
+        let queue_manager = TeamQueueManager::new(
+            request.session_id,
+            *session.game_mode(),
+            *session.settings().players_per_team(),
+        );
+
+        let session_players: Vec<_> = self
+            .player_repository
+            .list()
+            .await?
+            .into_iter()
+            .filter(|player| session.player_ids().contains(player.id()))
+            .collect();
+
+        let broken_ids: HashSet<Uuid> = broken_origin_teams
+            .iter()
+            .map(|(team, _)| *team.id())
+            .collect();
+        let mut remaining_waiting_teams: Vec<Team> = existing_teams
+            .into_iter()
+            .filter(|team| team.is_waiting() && !broken_ids.contains(team.id()))
+            .collect();
+
+        for (mut origin, leftover_player_ids) in broken_origin_teams {
+            origin.disband();
+            self.team_repository.insert(origin).await?;
+
+            if leftover_player_ids.is_empty() {
+                continue;
+            }
+
+            let changed_teams = queue_manager.release_players(
+                &remaining_waiting_teams,
+                &leftover_player_ids,
+                &session_players,
+                &history,
+            );
+
+            for changed in changed_teams {
+                self.team_repository.insert(changed.clone()).await?;
+
+                match remaining_waiting_teams
+                    .iter_mut()
+                    .find(|team| team.id() == changed.id())
+                {
+                    Some(existing) => *existing = changed,
+                    None => remaining_waiting_teams.push(changed),
+                }
+            }
+        }
+
+        let team = Team::new(request.session_id, request.player_ids).with_priority();
 
         self.team_repository.insert(team).await
     }

--- a/api/src/modules/matchmaking/routes/team.rs
+++ b/api/src/modules/matchmaking/routes/team.rs
@@ -14,6 +14,7 @@ pub fn configure_routes() -> Router<AppState> {
         "/teams",
         Router::new()
             .route("/", post(create_team))
+            .route("/priority", post(create_priority_team))
             .route("/{session_id}", get(list_teams_by_session))
             .route("/{session_id}/draw", post(draw_teams)),
     )
@@ -27,6 +28,19 @@ async fn create_team(
         .matchmaking_state
         .team_handler
         .create_team(request)
+        .await?;
+
+    Ok(Json(team))
+}
+
+async fn create_priority_team(
+    state: State<AppState>,
+    Json(request): Json<CreateTeamRequest>,
+) -> HttpResult<impl IntoResponse> {
+    let team = state
+        .matchmaking_state
+        .team_handler
+        .create_priority_team(request)
         .await?;
 
     Ok(Json(team))


### PR DESCRIPTION
Add POST /matchmaking/teams/priority so an operator can pick exactly who plays next on a court, skipping the normal FIFO queue and the draw's gender/fresh-partner rules — the contingency case where a specific pairing needs to go on court next regardless of how the automatic rotation would order it.

Team gains a `priority` flag (Team::with_priority) that TeamQueueManager::next_complete_teams now sorts ahead of everything else. Unlike create_team, this path can pull a player out of another Waiting team that isn't mid-match: that origin team is disbanded and its now partner-less teammate is re-slotted back into the queue via the same TeamQueueManager::release_players path used for players freed by a match result.