### PR TITLE
feat(matchmaking): persist repositories to Postgres

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Contexto de negócio e regras específicas de cada módulo (complementa a seçã
 
 Responsável por organizar sorteio de equipes para partidas de esportes. Hoje roda como módulo dentro do serviço `api` (não como processo separado), pela limitação de infraestrutura descrita no topo deste arquivo.
 
-Caso de uso atual: sorteio para um grupo de vôlei de praia (beach volley) — jogadores (`Player`), dias de jogo (`Session`, com configurações padrão e quadras disponíveis), duplas (`Team`) e partidas registradas (`Match`). Repositórios hoje são em cache (memória do processo, sem migration) enquanto o modelo ainda está sendo validado. As regras de sorteio (critérios de balanceamento de times, restrições, etc.) ainda serão definidas e documentadas aqui conforme forem implementadas nos próximos PRs.
+Caso de uso atual: sorteio para um grupo de vôlei de praia (beach volley) — jogadores (`Player`), dias de jogo (`Session`, com configurações padrão e quadras disponíveis), duplas (`Team`) e partidas registradas (`Match`). Repositórios são persistidos em Postgres (schema `matchmaking`, migrations em `migrations/matchmaking`), no mesmo padrão dos demais módulos. As regras de sorteio (critérios de balanceamento de times, restrições, etc.) ainda serão definidas e documentadas aqui conforme forem implementadas nos próximos PRs.
 
 ## Comandos
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -28,8 +28,8 @@ use api::modules::{
             team::TeamHandlerImpl,
         },
         repository::{
-            matches::InMemoryMatchRepository, player::InMemoryPlayerRepository,
-            session::InMemorySessionRepository, team::InMemoryTeamRepository,
+            matches::MatchRepositoryImpl, player::PlayerRepositoryImpl,
+            session::SessionRepositoryImpl, team::TeamRepositoryImpl,
         },
         MatchmakingState,
     },
@@ -67,7 +67,7 @@ async fn main() {
         auth_handler: Arc::new(auth_handler),
     };
 
-    let matchmaking_state = build_matchmaking_state();
+    let matchmaking_state = build_matchmaking_state(pool);
 
     let app_state = AppState {
         finance_manager_state: Arc::new(finance_manager_state),
@@ -128,11 +128,11 @@ fn build_income_handler(pool: &Pool<Postgres>) -> IncomeHandlerImpl {
     }
 }
 
-fn build_matchmaking_state() -> MatchmakingState {
-    let player_repository = Arc::new(InMemoryPlayerRepository::new());
-    let session_repository = Arc::new(InMemorySessionRepository::new());
-    let team_repository = Arc::new(InMemoryTeamRepository::new());
-    let match_repository = Arc::new(InMemoryMatchRepository::new());
+fn build_matchmaking_state(pool: &Pool<Postgres>) -> MatchmakingState {
+    let player_repository = Arc::new(PlayerRepositoryImpl::new(pool));
+    let session_repository = Arc::new(SessionRepositoryImpl::new(pool));
+    let team_repository = Arc::new(TeamRepositoryImpl::new(pool));
+    let match_repository = Arc::new(MatchRepositoryImpl::new(pool));
 
     let team_handler = Arc::new(TeamHandlerImpl {
         team_repository,

--- a/api/src/modules/matchmaking/domain/matches.rs
+++ b/api/src/modules/matchmaking/domain/matches.rs
@@ -167,6 +167,23 @@ getters! {
     }
 }
 
+impl From<&sqlx::postgres::PgRow> for Match {
+    fn from(row: &sqlx::postgres::PgRow) -> Self {
+        use sqlx::Row;
+
+        Self {
+            id: row.get("id"),
+            session_id: row.get("session_id"),
+            court: row.get::<i16, _>("court") as u8,
+            team_a_id: row.get("team_a_id"),
+            team_b_id: row.get("team_b_id"),
+            winner_team_id: row.get("winner_team_id"),
+            started_at: row.get("started_at"),
+            played_at: row.get("played_at"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http_error::HttpErrorKind;

--- a/api/src/modules/matchmaking/domain/player.rs
+++ b/api/src/modules/matchmaking/domain/player.rs
@@ -10,6 +10,24 @@ pub enum Gender {
     Female,
 }
 
+impl From<String> for Gender {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "FEMALE" => Gender::Female,
+            _ => Gender::Male,
+        }
+    }
+}
+
+impl From<Gender> for String {
+    fn from(gender: Gender) -> Self {
+        match gender {
+            Gender::Male => "MALE".to_string(),
+            Gender::Female => "FEMALE".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Player {
@@ -49,5 +67,19 @@ getters! {
         gender: Gender,
         created_at: DateTime<Utc>,
         updated_at: Option<DateTime<Utc>>,
+    }
+}
+
+impl From<&sqlx::postgres::PgRow> for Player {
+    fn from(row: &sqlx::postgres::PgRow) -> Self {
+        use sqlx::Row;
+
+        Self {
+            id: row.get("id"),
+            name: row.get("name"),
+            gender: row.get::<String, _>("gender").into(),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        }
     }
 }

--- a/api/src/modules/matchmaking/domain/session.rs
+++ b/api/src/modules/matchmaking/domain/session.rs
@@ -68,6 +68,28 @@ impl GameMode {
     }
 }
 
+impl From<String> for GameMode {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "FEMALE" => GameMode::Female,
+            "MIXED" => GameMode::Mixed,
+            "OPEN" => GameMode::Open,
+            _ => GameMode::Male,
+        }
+    }
+}
+
+impl From<GameMode> for String {
+    fn from(game_mode: GameMode) -> Self {
+        match game_mode {
+            GameMode::Male => "MALE".to_string(),
+            GameMode::Female => "FEMALE".to_string(),
+            GameMode::Mixed => "MIXED".to_string(),
+            GameMode::Open => "OPEN".to_string(),
+        }
+    }
+}
+
 /// The strategy governing how a session's team queue evolves as matches
 /// finish.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,6 +102,24 @@ pub enum ShuffleType {
     /// pairing while a fresh alternative exists. Only valid with
     /// `GameMode::Open`.
     RoundRobin,
+}
+
+impl From<String> for ShuffleType {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "ROUND_ROBIN" => ShuffleType::RoundRobin,
+            _ => ShuffleType::KingAndQueen,
+        }
+    }
+}
+
+impl From<ShuffleType> for String {
+    fn from(shuffle_type: ShuffleType) -> Self {
+        match shuffle_type {
+            ShuffleType::KingAndQueen => "KING_AND_QUEEN".to_string(),
+            ShuffleType::RoundRobin => "ROUND_ROBIN".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -221,6 +261,30 @@ getters! {
         player_ids: Vec<Uuid>,
         created_at: DateTime<Utc>,
         updated_at: Option<DateTime<Utc>>,
+    }
+}
+
+impl From<&sqlx::postgres::PgRow> for Session {
+    fn from(row: &sqlx::postgres::PgRow) -> Self {
+        use sqlx::Row;
+
+        let settings = SessionSettings {
+            players_per_team: row.get::<i16, _>("players_per_team") as u8,
+            sets_to_win: row.get::<i16, _>("sets_to_win") as u8,
+            points_per_set: row.get::<i16, _>("points_per_set") as u8,
+        };
+
+        Self {
+            id: row.get("id"),
+            date: row.get("date"),
+            settings,
+            available_courts: row.get::<i16, _>("available_courts") as u8,
+            game_mode: row.get::<String, _>("game_mode").into(),
+            shuffle_type: row.get::<String, _>("shuffle_type").into(),
+            player_ids: row.get("player_ids"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        }
     }
 }
 

--- a/api/src/modules/matchmaking/domain/team.rs
+++ b/api/src/modules/matchmaking/domain/team.rs
@@ -18,6 +18,26 @@ pub enum TeamStatus {
     Disbanded,
 }
 
+impl From<String> for TeamStatus {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "HOLDING" => TeamStatus::Holding,
+            "DISBANDED" => TeamStatus::Disbanded,
+            _ => TeamStatus::Waiting,
+        }
+    }
+}
+
+impl From<TeamStatus> for String {
+    fn from(status: TeamStatus) -> Self {
+        match status {
+            TeamStatus::Waiting => "WAITING".to_string(),
+            TeamStatus::Holding => "HOLDING".to_string(),
+            TeamStatus::Disbanded => "DISBANDED".to_string(),
+        }
+    }
+}
+
 /// A pair/team formed from the players confirmed in a `Session`,
 /// used to compose that day's matches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,6 +135,22 @@ getters! {
         status: TeamStatus,
         consecutive_wins: u8,
         created_at: DateTime<Utc>,
+    }
+}
+
+impl From<&sqlx::postgres::PgRow> for Team {
+    fn from(row: &sqlx::postgres::PgRow) -> Self {
+        use sqlx::Row;
+
+        Self {
+            id: row.get("id"),
+            session_id: row.get("session_id"),
+            player_ids: row.get("player_ids"),
+            status: row.get::<String, _>("status").into(),
+            consecutive_wins: row.get::<i16, _>("consecutive_wins") as u8,
+            priority: row.get("priority"),
+            created_at: row.get("created_at"),
+        }
     }
 }
 
@@ -514,7 +550,11 @@ mod tests {
         let player_ids = vec![stolen_player, new_partner];
 
         let broken = validator
-            .validate_priority_team(std::slice::from_ref(&origin_team), &HashSet::new(), &player_ids)
+            .validate_priority_team(
+                std::slice::from_ref(&origin_team),
+                &HashSet::new(),
+                &player_ids,
+            )
             .unwrap();
 
         assert_eq!(broken.len(), 1);

--- a/api/src/modules/matchmaking/repository/matches.rs
+++ b/api/src/modules/matchmaking/repository/matches.rs
@@ -1,7 +1,6 @@
-use std::{collections::HashMap, sync::Mutex};
-
 use async_trait::async_trait;
 use http_error::HttpResult;
+use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::domain::matches::Match;
@@ -19,48 +18,76 @@ pub trait MatchRepository {
 
 pub type DynMatchRepository = dyn MatchRepository + Send + Sync;
 
-/// Process-memory cache repository, no database persistence.
-/// Lets the pairing logic be tested before a migration exists.
-#[derive(Default)]
-pub struct InMemoryMatchRepository {
-    matches: Mutex<HashMap<Uuid, Match>>,
+pub struct MatchRepositoryImpl {
+    pool: Pool<Postgres>,
 }
 
-impl InMemoryMatchRepository {
-    pub fn new() -> Self {
-        Self::default()
+impl MatchRepositoryImpl {
+    pub fn new(pool: &Pool<Postgres>) -> Self {
+        Self { pool: pool.clone() }
     }
 }
 
 #[async_trait]
-impl MatchRepository for InMemoryMatchRepository {
+impl MatchRepository for MatchRepositoryImpl {
     async fn insert(&self, match_: Match) -> HttpResult<Match> {
-        let mut matches = self.matches.lock().expect("match repository lock poisoned");
-        matches.insert(*match_.id(), match_.clone());
+        let row = sqlx::query(
+            r#"
+            INSERT INTO matchmaking.match (
+                id, session_id, court, team_a_id, team_b_id, winner_team_id, started_at, played_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            "#,
+        )
+        .bind(*match_.id())
+        .bind(*match_.session_id())
+        .bind(*match_.court() as i16)
+        .bind(*match_.team_a_id())
+        .bind(*match_.team_b_id())
+        .bind(*match_.winner_team_id())
+        .bind(*match_.started_at())
+        .bind(*match_.played_at())
+        .fetch_one(&self.pool)
+        .await?;
 
-        Ok(match_)
+        Ok(Match::from(&row))
     }
 
     async fn list_by_session(&self, session_id: &Uuid) -> HttpResult<Vec<Match>> {
-        let matches = self.matches.lock().expect("match repository lock poisoned");
+        let rows = sqlx::query("SELECT * FROM matchmaking.match WHERE session_id = $1")
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
 
-        Ok(matches
-            .values()
-            .filter(|match_| match_.session_id() == session_id)
-            .cloned()
-            .collect())
+        Ok(rows.iter().map(Match::from).collect())
     }
 
     async fn get(&self, id: &Uuid) -> HttpResult<Option<Match>> {
-        let matches = self.matches.lock().expect("match repository lock poisoned");
+        let row = sqlx::query("SELECT * FROM matchmaking.match WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(matches.get(id).cloned())
+        Ok(row.as_ref().map(Match::from))
     }
 
     async fn update(&self, match_: Match) -> HttpResult<Match> {
-        let mut matches = self.matches.lock().expect("match repository lock poisoned");
-        matches.insert(*match_.id(), match_.clone());
+        let row = sqlx::query(
+            r#"
+            UPDATE matchmaking.match SET
+                winner_team_id = $2,
+                played_at = $3
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(*match_.id())
+        .bind(*match_.winner_team_id())
+        .bind(*match_.played_at())
+        .fetch_one(&self.pool)
+        .await?;
 
-        Ok(match_)
+        Ok(Match::from(&row))
     }
 }

--- a/api/src/modules/matchmaking/repository/player.rs
+++ b/api/src/modules/matchmaking/repository/player.rs
@@ -1,10 +1,9 @@
-use std::{collections::HashMap, sync::Mutex};
-
 use async_trait::async_trait;
 use http_error::HttpResult;
+use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use crate::modules::matchmaking::domain::player::{Gender, Player};
+use crate::modules::matchmaking::domain::player::Player;
 
 #[async_trait]
 pub trait PlayerRepository {
@@ -19,85 +18,76 @@ pub trait PlayerRepository {
 
 pub type DynPlayerRepository = dyn PlayerRepository + Send + Sync;
 
-/// Process-memory cache repository, no database persistence.
-/// Lets the pairing logic be tested before a migration exists.
-#[derive(Default)]
-pub struct InMemoryPlayerRepository {
-    players: Mutex<HashMap<Uuid, Player>>,
+pub struct PlayerRepositoryImpl {
+    pool: Pool<Postgres>,
 }
 
-const DEFAULT_PLAYERS: [(&str, Gender); 16] = [
-    ("Gabriel", Gender::Male),
-    ("Bru Varella", Gender::Female),
-    ("Luan", Gender::Male),
-    ("Jully", Gender::Female),
-    ("Brenda", Gender::Female),
-    ("Flavia", Gender::Female),
-    ("Marcos", Gender::Male),
-    ("Roberta", Gender::Female),
-    ("Serginho", Gender::Male),
-    ("Valdeta", Gender::Female),
-    ("Alessandra", Gender::Female),
-    ("Andre", Gender::Male),
-    ("Angela", Gender::Female),
-    ("Douglas", Gender::Male),
-    ("Gabe", Gender::Male),
-    ("Valdenia", Gender::Female),
-];
-
-impl InMemoryPlayerRepository {
-    pub fn new() -> Self {
-        let players = DEFAULT_PLAYERS
-            .into_iter()
-            .map(|(name, gender)| {
-                let player = Player::new(name.to_string(), gender);
-                (*player.id(), player)
-            })
-            .collect();
-
-        Self {
-            players: Mutex::new(players),
-        }
+impl PlayerRepositoryImpl {
+    pub fn new(pool: &Pool<Postgres>) -> Self {
+        Self { pool: pool.clone() }
     }
 }
 
 #[async_trait]
-impl PlayerRepository for InMemoryPlayerRepository {
+impl PlayerRepository for PlayerRepositoryImpl {
     async fn insert(&self, player: Player) -> HttpResult<Player> {
-        let mut players = self
-            .players
-            .lock()
-            .expect("player repository lock poisoned");
-        players.insert(*player.id(), player.clone());
+        let gender: String = (*player.gender()).into();
 
-        Ok(player)
+        let row = sqlx::query(
+            r#"
+            INSERT INTO matchmaking.player (id, name, gender, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            "#,
+        )
+        .bind(*player.id())
+        .bind(player.name())
+        .bind(gender)
+        .bind(*player.created_at())
+        .bind(*player.updated_at())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(Player::from(&row))
     }
 
     async fn list(&self) -> HttpResult<Vec<Player>> {
-        let players = self
-            .players
-            .lock()
-            .expect("player repository lock poisoned");
+        let rows = sqlx::query("SELECT * FROM matchmaking.player")
+            .fetch_all(&self.pool)
+            .await?;
 
-        Ok(players.values().cloned().collect())
+        Ok(rows.iter().map(Player::from).collect())
     }
 
     async fn get(&self, id: &Uuid) -> HttpResult<Option<Player>> {
-        let players = self
-            .players
-            .lock()
-            .expect("player repository lock poisoned");
+        let row = sqlx::query("SELECT * FROM matchmaking.player WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(players.get(id).cloned())
+        Ok(row.as_ref().map(Player::from))
     }
 
     async fn update(&self, player: Player) -> HttpResult<Player> {
-        let mut players = self
-            .players
-            .lock()
-            .expect("player repository lock poisoned");
-        players.insert(*player.id(), player.clone());
+        let gender: String = (*player.gender()).into();
 
-        Ok(player)
+        let row = sqlx::query(
+            r#"
+            UPDATE matchmaking.player SET
+                name = $2,
+                gender = $3,
+                updated_at = $4
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(*player.id())
+        .bind(player.name())
+        .bind(gender)
+        .bind(*player.updated_at())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(Player::from(&row))
     }
 }

--- a/api/src/modules/matchmaking/repository/session.rs
+++ b/api/src/modules/matchmaking/repository/session.rs
@@ -1,7 +1,6 @@
-use std::{collections::HashMap, sync::Mutex};
-
 use async_trait::async_trait;
 use http_error::HttpResult;
+use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::domain::session::Session;
@@ -19,56 +18,102 @@ pub trait SessionRepository {
 
 pub type DynSessionRepository = dyn SessionRepository + Send + Sync;
 
-/// Process-memory cache repository, no database persistence.
-/// Lets the pairing logic be tested before a migration exists.
-#[derive(Default)]
-pub struct InMemorySessionRepository {
-    sessions: Mutex<HashMap<Uuid, Session>>,
+pub struct SessionRepositoryImpl {
+    pool: Pool<Postgres>,
 }
 
-impl InMemorySessionRepository {
-    pub fn new() -> Self {
-        Self::default()
+impl SessionRepositoryImpl {
+    pub fn new(pool: &Pool<Postgres>) -> Self {
+        Self { pool: pool.clone() }
     }
 }
 
 #[async_trait]
-impl SessionRepository for InMemorySessionRepository {
+impl SessionRepository for SessionRepositoryImpl {
     async fn insert(&self, session: Session) -> HttpResult<Session> {
-        let mut sessions = self
-            .sessions
-            .lock()
-            .expect("session repository lock poisoned");
-        sessions.insert(*session.id(), session.clone());
+        let game_mode: String = (*session.game_mode()).into();
+        let shuffle_type: String = (*session.shuffle_type()).into();
+        let player_ids = Vec::from_iter(session.player_ids().iter().copied());
 
-        Ok(session)
+        let row = sqlx::query(
+            r#"
+            INSERT INTO matchmaking.session (
+                id, date, players_per_team, sets_to_win, points_per_set,
+                available_courts, game_mode, shuffle_type, player_ids,
+                created_at, updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING *
+            "#,
+        )
+        .bind(*session.id())
+        .bind(*session.date())
+        .bind(*session.settings().players_per_team() as i16)
+        .bind(*session.settings().sets_to_win() as i16)
+        .bind(*session.settings().points_per_set() as i16)
+        .bind(*session.available_courts() as i16)
+        .bind(game_mode)
+        .bind(shuffle_type)
+        .bind(player_ids)
+        .bind(*session.created_at())
+        .bind(*session.updated_at())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(Session::from(&row))
     }
 
     async fn list(&self) -> HttpResult<Vec<Session>> {
-        let sessions = self
-            .sessions
-            .lock()
-            .expect("session repository lock poisoned");
+        let rows = sqlx::query("SELECT * FROM matchmaking.session")
+            .fetch_all(&self.pool)
+            .await?;
 
-        Ok(sessions.values().cloned().collect())
+        Ok(rows.iter().map(Session::from).collect())
     }
 
     async fn get(&self, id: &Uuid) -> HttpResult<Option<Session>> {
-        let sessions = self
-            .sessions
-            .lock()
-            .expect("session repository lock poisoned");
+        let row = sqlx::query("SELECT * FROM matchmaking.session WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(sessions.get(id).cloned())
+        Ok(row.as_ref().map(Session::from))
     }
 
     async fn update(&self, session: Session) -> HttpResult<Session> {
-        let mut sessions = self
-            .sessions
-            .lock()
-            .expect("session repository lock poisoned");
-        sessions.insert(*session.id(), session.clone());
+        let game_mode: String = (*session.game_mode()).into();
+        let shuffle_type: String = (*session.shuffle_type()).into();
+        let player_ids = Vec::from_iter(session.player_ids().iter().copied());
 
-        Ok(session)
+        let row = sqlx::query(
+            r#"
+            UPDATE matchmaking.session SET
+                date = $2,
+                players_per_team = $3,
+                sets_to_win = $4,
+                points_per_set = $5,
+                available_courts = $6,
+                game_mode = $7,
+                shuffle_type = $8,
+                player_ids = $9,
+                updated_at = $10
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(*session.id())
+        .bind(*session.date())
+        .bind(*session.settings().players_per_team() as i16)
+        .bind(*session.settings().sets_to_win() as i16)
+        .bind(*session.settings().points_per_set() as i16)
+        .bind(*session.available_courts() as i16)
+        .bind(game_mode)
+        .bind(shuffle_type)
+        .bind(player_ids)
+        .bind(*session.updated_at())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(Session::from(&row))
     }
 }

--- a/api/src/modules/matchmaking/repository/team.rs
+++ b/api/src/modules/matchmaking/repository/team.rs
@@ -1,7 +1,6 @@
-use std::{collections::HashMap, sync::Mutex};
-
 use async_trait::async_trait;
 use http_error::HttpResult;
+use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
 use crate::modules::matchmaking::domain::team::Team;
@@ -17,41 +16,67 @@ pub trait TeamRepository {
 
 pub type DynTeamRepository = dyn TeamRepository + Send + Sync;
 
-/// Process-memory cache repository, no database persistence.
-/// Lets the pairing logic be tested before a migration exists.
-#[derive(Default)]
-pub struct InMemoryTeamRepository {
-    teams: Mutex<HashMap<Uuid, Team>>,
+pub struct TeamRepositoryImpl {
+    pool: Pool<Postgres>,
 }
 
-impl InMemoryTeamRepository {
-    pub fn new() -> Self {
-        Self::default()
+impl TeamRepositoryImpl {
+    pub fn new(pool: &Pool<Postgres>) -> Self {
+        Self { pool: pool.clone() }
     }
 }
 
 #[async_trait]
-impl TeamRepository for InMemoryTeamRepository {
+impl TeamRepository for TeamRepositoryImpl {
+    /// Also used to persist an already-existing team after a mutation (see
+    /// `Team::disband`/`register_win`/`add_player`) — the trait has no
+    /// separate `update`, so this upserts on `id` instead.
     async fn insert(&self, team: Team) -> HttpResult<Team> {
-        let mut teams = self.teams.lock().expect("team repository lock poisoned");
-        teams.insert(*team.id(), team.clone());
+        let status: String = (*team.status()).into();
+        let player_ids = Vec::from_iter(team.player_ids().iter().copied());
 
-        Ok(team)
+        let row = sqlx::query(
+            r#"
+            INSERT INTO matchmaking.team (
+                id, session_id, player_ids, status, consecutive_wins, priority, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (id) DO UPDATE SET
+                player_ids = EXCLUDED.player_ids,
+                status = EXCLUDED.status,
+                consecutive_wins = EXCLUDED.consecutive_wins,
+                priority = EXCLUDED.priority
+            RETURNING *
+            "#,
+        )
+        .bind(*team.id())
+        .bind(*team.session_id())
+        .bind(player_ids)
+        .bind(status)
+        .bind(*team.consecutive_wins() as i16)
+        .bind(team.is_priority())
+        .bind(*team.created_at())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(Team::from(&row))
     }
 
     async fn list_by_session(&self, session_id: &Uuid) -> HttpResult<Vec<Team>> {
-        let teams = self.teams.lock().expect("team repository lock poisoned");
+        let rows = sqlx::query("SELECT * FROM matchmaking.team WHERE session_id = $1")
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
 
-        Ok(teams
-            .values()
-            .filter(|team| team.session_id() == session_id)
-            .cloned()
-            .collect())
+        Ok(rows.iter().map(Team::from).collect())
     }
 
     async fn get(&self, id: &Uuid) -> HttpResult<Option<Team>> {
-        let teams = self.teams.lock().expect("team repository lock poisoned");
+        let row = sqlx::query("SELECT * FROM matchmaking.team WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(teams.get(id).cloned())
+        Ok(row.as_ref().map(Team::from))
     }
 }

--- a/migrations/matchmaking/20260817120000_init-matchmaking-schema.sql
+++ b/migrations/matchmaking/20260817120000_init-matchmaking-schema.sql
@@ -1,0 +1,48 @@
+CREATE SCHEMA IF NOT EXISTS matchmaking;
+
+CREATE TABLE matchmaking.player (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    gender TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NULL
+);
+
+CREATE TABLE matchmaking.session (
+    id UUID PRIMARY KEY,
+    date DATE NOT NULL,
+    players_per_team SMALLINT NOT NULL,
+    sets_to_win SMALLINT NOT NULL,
+    points_per_set SMALLINT NOT NULL,
+    available_courts SMALLINT NOT NULL,
+    game_mode TEXT NOT NULL,
+    shuffle_type TEXT NOT NULL,
+    player_ids UUID[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NULL
+);
+
+CREATE TABLE matchmaking.team (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES matchmaking.session (id),
+    player_ids UUID[] NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL,
+    consecutive_wins SMALLINT NOT NULL DEFAULT 0,
+    priority BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_team_session_id ON matchmaking.team (session_id);
+
+CREATE TABLE matchmaking.match (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES matchmaking.session (id),
+    court SMALLINT NOT NULL,
+    team_a_id UUID NOT NULL REFERENCES matchmaking.team (id),
+    team_b_id UUID NOT NULL REFERENCES matchmaking.team (id),
+    winner_team_id UUID NULL REFERENCES matchmaking.team (id),
+    started_at TIMESTAMPTZ NOT NULL,
+    played_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX idx_match_session_id ON matchmaking.match (session_id);


### PR DESCRIPTION
Replaces the in-memory cache repositories for player, session, team and match with SQL-backed implementations, plus the migration for the matchmaking schema. Enum fields (Gender, GameMode, ShuffleType, TeamStatus) round-trip through TEXT columns via From<String>/Into<String>, matching the finance_manager convention. Team keeps its upsert-on-insert semantics (ON CONFLICT DO UPDATE) since its trait has no separate update method.